### PR TITLE
Add application/pdf intent filters

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,12 +35,32 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:host="*" />
+                <data android:scheme="smb" />
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+                <data android:mimeType="application/pdf" />
+            </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:host="*" />
                 <data android:scheme="file" />
                 <data android:scheme="content" />
-                <data android:mimeType="*/*" />
                 <data android:pathPattern=".*\\.pdf" />
                 <data android:pathPattern=".*\\..*\\.pdf" />
                 <data android:pathPattern=".*\\..*\\..*\\.pdf" />
+            </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:host="*" />
+                <data android:scheme="file" />
+                <data android:scheme="content" />
+                <data android:mimeType="application/pdf" />
             </intent-filter>
         </activity>
 


### PR DESCRIPTION
Hi,

Thank you for this simple, lightweight PDF reader app!
Everything works for me except opening PDF files from other apps on my Android 7.1.1.

After digging a bit with Android Studio, I was able to resolve that by adding separate intent filters targeting the `application/pdf` MIME type, as suggested by [this answer](https://stackoverflow.com/a/5097734). Specifying both MIME and file extension in the same intent filter did not work for me, I think they have to be separate in order to target `.pdf` and `application/pdf` independently, otherwise both conditions would be required to match the file.

I think other users may benefit from this fix, so here is a pull request :wink:
Keep up the good work!