### PR TITLE
Increase maximum zoom from 3x to 5x

### DIFF
--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -245,12 +245,12 @@ public class MainActivity extends ProgressActivity implements OnPageChangeListen
     }
 
 
-    void displayFromAsset(String assetFileName) {
-        pdfFileName = assetFileName;
-
+    void setPdfViewConfiguration() {
         pdfView.useBestQuality(prefManager.getBoolean("quality_pref", false));
+    }
 
-        pdfView.fromAsset(assetFileName)
+    void setPageConfigurationAndLoad(PDFView.Configurator configurator) {
+        configurator
                 .defaultPage(pageNumber)
                 .onPageChange(this)
                 .enableAnnotationRendering(true)
@@ -266,6 +266,14 @@ public class MainActivity extends ProgressActivity implements OnPageChangeListen
                 .pageSnap(prefManager.getBoolean("snap_pref", false))
                 .pageFling(prefManager.getBoolean("fling_pref", false))
                 .load();
+    }
+
+
+    void displayFromAsset(String assetFileName) {
+        pdfFileName = assetFileName;
+
+        setPdfViewConfiguration();
+        setPageConfigurationAndLoad(pdfView.fromAsset(assetFileName));
     }
 
     void displayFromUri(Uri uri) {
@@ -281,56 +289,19 @@ public class MainActivity extends ProgressActivity implements OnPageChangeListen
             DownloadPDFFile DownloadPDFFile = new DownloadPDFFile(this);
             DownloadPDFFile.execute(uri.toString(), pdfFileName);
         } else {
-            pdfView.useBestQuality(prefManager.getBoolean("quality_pref", false));
-
-            pdfView.fromUri(uri)
-                    .defaultPage(pageNumber)
-                    .onPageChange(this)
-                    .enableAnnotationRendering(true)
-                    .enableAntialiasing(prefManager.getBoolean("alias_pref", false))
-                    .onLoad(this)
-                    .scrollHandle(new DefaultScrollHandle(this))
-                    .spacing(10) // in dp
-                    .onPageError(this)
-                    .pageFitPolicy(FitPolicy.BOTH)
-                    .password(PDF_PASSWORD)
-                    .swipeHorizontal(prefManager.getBoolean("scroll_pref", false))
-                    .autoSpacing(prefManager.getBoolean("scroll_pref", false))
-                    .pageSnap(prefManager.getBoolean("snap_pref", false))
-                    .pageFling(prefManager.getBoolean("fling_pref", false))
-                    .load();
+            setPdfViewConfiguration();
+            setPageConfigurationAndLoad(pdfView.fromUri(uri));
         }
     }
 
     void displayFromFile(File file) {
-        pdfView.useBestQuality(prefManager.getBoolean("quality_pref", false));
-
-        pdfView.fromFile(file)
-                .defaultPage(pageNumber)
-                .onPageChange(this)
-                .enableAnnotationRendering(true)
-                .enableAntialiasing(prefManager.getBoolean("alias_pref", false))
-                .onLoad(this)
-                .scrollHandle(new DefaultScrollHandle(this))
-                .spacing(10) // in dp
-                .onPageError(this)
-                .pageFitPolicy(FitPolicy.BOTH)
-                .password(PDF_PASSWORD)
-                .swipeHorizontal(prefManager.getBoolean("scroll_pref", false))
-                .autoSpacing(prefManager.getBoolean("scroll_pref", false))
-                .pageSnap(prefManager.getBoolean("snap_pref", false))
-                .pageFling(prefManager.getBoolean("fling_pref", false))
-                .load();
-
+        setPdfViewConfiguration();
+        setPageConfigurationAndLoad(pdfView.fromFile(file));
     }
 
     public void saveFileAndDisplay(File file) {
         String filePath = saveTempFileToFile(file);
-
-        pdfView.useBestQuality(prefManager.getBoolean("quality_pref", false));
-
         File newFile = new File(filePath);
-
         displayFromFile(newFile);
     }
 

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -247,6 +247,8 @@ public class MainActivity extends ProgressActivity implements OnPageChangeListen
 
     void setPdfViewConfiguration() {
         pdfView.useBestQuality(prefManager.getBoolean("quality_pref", false));
+        pdfView.setMidZoom(2.0f);
+        pdfView.setMaxZoom(5.0f);
     }
 
     void setPageConfigurationAndLoad(PDFView.Configurator configurator) {


### PR DESCRIPTION
Sometimes I view very condensed PDFs, so I need to zoom further than only 3x. This pr increases the maximum zoom level to 5x, and accordingly increases by a little bit the mid zoom level (from the default 1.75x to 2x). This means that by double-tapping one time the zoom becomes 2x, with two double-taps it becomes 5x. So this pr also fixes #22 
I extracted some duplicate code spells into their own functions (see `setPdfViewConfiguration` and `setPageConfigurationAndLoad`).

I tested the app by opening PDFs multiple ways (i.e. sample file, downloaded file, view button on my Email client) and it always worked. Here is a test APK: [app-debug.zip](https://github.com/JavaCafe01/PdfViewer/files/4176962/app-debug.zip)
