### PR TITLE
Fixing Two Bugs

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:requestLegacyExternalStorage="true"
         android:theme="@style/Theme.Cyanea.Light.DarkActionBar">
 
         <activity

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -390,7 +390,7 @@ public class MainActivity extends ProgressActivity implements OnPageChangeListen
 
         final EditText input = new EditText(this);
         input.setPadding(19, 19, 19, 19);
-        input.setInputType(InputType.TYPE_TEXT_VARIATION_PASSWORD);
+        input.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
 
         new AlertDialog.Builder(this)
                 .setTitle(R.string.password)


### PR DESCRIPTION
On my device Pixel 3aXL running Android 10. The password EditText in the AlertDialog was not hiding the password as it was being typed.  I fixed this in commit 7fb2876.  The app would crash from a NullPointerException when one would try to open a PDF that was access from a web browser.  This is due to a changes in storage access rules on Android 10.  To overcome this issue I modified the manifest in commit c05aab7. 