### PR TITLE
Add explanation for "Page Snap" and "Page Fling" options

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,7 +102,7 @@
     <string name="settings">Settings</string>
     <string name="alias">Anti-Aliasing</string>
     <string name="scroll">Horizontal Scrolling</string>
-    <string name="snap" translatable="false">Page Snap</string>
+    <string name="snap">Page Snap</string>
     <string name="fling">Page Fling</string>
     <string name="qualitysettings">Quality</string>
     <string name="scrollsettings">Scrolling</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -103,7 +103,9 @@
     <string name="alias">Anti-Aliasing</string>
     <string name="scroll">Horizontal Scrolling</string>
     <string name="snap">Page Snap</string>
+    <string name="snap_summary">Center the view on the current page after each swipe</string>
     <string name="fling">Page Fling</string>
+    <string name="fling_summary">Perform a quick swipe to jump directly to the next page</string>
     <string name="qualitysettings">Quality</string>
     <string name="scrollsettings">Scrolling</string>
     <string name="title_activity_settings">Settings</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -24,11 +24,13 @@
 
         <SwitchPreference
             android:defaultValue="false"
-            android:title="@string/snap" android:key="snap_pref"/>
+            android:title="@string/snap"
+            android:summary="@string/snap_summary" android:key="snap_pref"/>
 
         <SwitchPreference
             android:defaultValue="false"
-            android:title="@string/fling" android:key="fling_pref"/>
+            android:title="@string/fling"
+            android:summary="@string/fling_summary" android:key="fling_pref"/>
 
     </PreferenceCategory>
 


### PR DESCRIPTION
This small PR adds summaries for the two aforementioned options, to make them more understandable for users and also to add some context for translators, so that their work can be more accurate.
As a consequence, "Page Snap" string has been made translatable.

Fixes #62

PS: This is the first PR of a series to make this nice app even nicer :)