### PR TITLE
Fix some graphical issues with themes that have a light primary color

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -77,7 +77,7 @@
             android:name=".AboutActivity"
             android:label="About"
             android:parentActivityName=".MainActivity_"
-            android:theme="@style/Theme.Cyanea.Light.NoActionBar">
+            android:theme="@style/Theme.Cyanea.Light.DarkActionBar">
 
             <!-- The meta-data tag is required if you support API level 15 and lower -->
             <meta-data

--- a/app/src/main/java/com/gsnathan/pdfviewer/AboutActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/AboutActivity.java
@@ -44,7 +44,6 @@ public class AboutActivity extends CyaneaAppCompatActivity {
     TextView versionView;   //shows the version
     private final String APP_VERSION_RELEASE = "Version " + Utils.getAppVersion();   //contains Version + the version number
     private final String APP_VERSION_DEBUG = "Version " + Utils.getAppVersion() + "-debug";   //contains Version + the version number + debug
-    private Toolbar toolbar;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -55,17 +54,13 @@ public class AboutActivity extends CyaneaAppCompatActivity {
     }
 
     private void setUpToolBar() {
-        setSupportActionBar(toolbar);
-        final long token = Binder.clearCallingIdentity();
+        Binder.clearCallingIdentity();
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-
     }
 
     private void initUI() {
         //initialize the textview
         versionView = (TextView) findViewById(R.id.versionTextView);
-        //initialize the toolbar
-        toolbar = (Toolbar) findViewById(R.id.toolbar_about);
 
         // check if app is debug
         if (BuildConfig.DEBUG) {

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -66,6 +66,7 @@ import com.github.barteksc.pdfviewer.scroll.DefaultScrollHandle;
 import com.github.barteksc.pdfviewer.util.Constants;
 import com.github.barteksc.pdfviewer.util.FitPolicy;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
+import com.google.android.material.shape.MaterialShapeDrawable;
 import com.jaredrummler.cyanea.prefs.CyaneaSettingsActivity;
 import com.kobakei.ratethisapp.RateThisApp;
 import com.shockwave.pdfium.PdfDocument;
@@ -245,7 +246,7 @@ public class MainActivity extends ProgressActivity implements OnPageChangeListen
     }
 
     private void setBottomBarListeners() {
-        BottomNavigationView bottomView = (BottomNavigationView) findViewById(R.id.bottom_navigation);
+        BottomNavigationView bottomView = findViewById(R.id.bottom_navigation);
         bottomView.setOnNavigationItemSelectedListener(new BottomNavigationView.OnNavigationItemSelectedListener() {
             @Override
             public boolean onNavigationItemSelected(@NonNull MenuItem item) {
@@ -278,6 +279,9 @@ public class MainActivity extends ProgressActivity implements OnPageChangeListen
                 return false;
             }
         });
+        // Workaround for https://issuetracker.google.com/issues/124153644
+        MaterialShapeDrawable viewBackground = (MaterialShapeDrawable) bottomView.getBackground();
+        viewBackground.setShadowCompatibilityMode(MaterialShapeDrawable.SHADOW_COMPAT_MODE_ALWAYS);
     }
 
     void setPdfViewConfiguration() {

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -33,8 +33,6 @@ import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.graphics.Color;
-import android.graphics.PorterDuff;
-import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Environment;
 import android.os.Handler;
@@ -77,6 +75,7 @@ import org.androidannotations.annotations.EActivity;
 import org.androidannotations.annotations.NonConfigurationInstance;
 import org.androidannotations.annotations.OnActivityResult;
 import org.androidannotations.annotations.ViewById;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -241,7 +240,44 @@ public class MainActivity extends ProgressActivity implements OnPageChangeListen
         }
         setTitle(pdfFileName);
         hideProgressDialog();
+        setBottomBarListeners();
         handler.post(runnable);
+    }
+
+    private void setBottomBarListeners() {
+        BottomNavigationView bottomView = (BottomNavigationView) findViewById(R.id.bottom_navigation);
+        bottomView.setOnNavigationItemSelectedListener(new BottomNavigationView.OnNavigationItemSelectedListener() {
+            @Override
+            public boolean onNavigationItemSelected(@NonNull MenuItem item) {
+                switch (item.getItemId()) {
+                    case R.id.pickFile:
+                        pickFile();
+                        break;
+                    case R.id.metaFile:
+                        if (uri != null)
+                            getMeta();
+                        break;
+                    case R.id.unlockFile:
+                        if (uri != null)
+                            unlockPDF();
+                        break;
+                    case R.id.shareFile:
+                        if (uri != null)
+                            shareFile();
+                        break;
+                    case R.id.printFile:
+                        if (uri != null)
+                            print(pdfFileName,
+                                    new PdfDocumentAdapter(getApplicationContext()),
+                                    new PrintAttributes.Builder().build());
+                        break;
+                    default:
+                        break;
+
+                }
+                return false;
+            }
+        });
     }
 
     void setPdfViewConfiguration() {
@@ -461,53 +497,8 @@ public class MainActivity extends ProgressActivity implements OnPageChangeListen
     }
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
+    public boolean onCreateOptionsMenu(@NotNull Menu menu) {
         getMenuInflater().inflate(R.menu.menu, menu);
-
-        BottomNavigationView bot_view = (BottomNavigationView) findViewById(R.id.bottom_navigation);
-        Menu bottomMenu = bot_view.getMenu();
-
-        for (int i = 0; i < bottomMenu.size() - 1; i++) {
-            Drawable drawable = bottomMenu.getItem(i).getIcon();
-            if (drawable != null) {
-                drawable.mutate();
-                drawable.setColorFilter(getResources().getColor(R.color.colorWhite), PorterDuff.Mode.SRC_ATOP);
-            }
-        }
-        bot_view.setOnNavigationItemSelectedListener(new BottomNavigationView.OnNavigationItemSelectedListener() {
-            @Override
-            public boolean onNavigationItemSelected(@NonNull MenuItem item) {
-
-                switch (item.getItemId()) {
-                    case R.id.pickFile:
-                        pickFile();
-                        break;
-                    case R.id.metaFile:
-                        if (uri != null)
-                            getMeta();
-                        break;
-                    case R.id.unlockFile:
-                        if (uri != null)
-                            unlockPDF();
-                        break;
-                    case R.id.shareFile:
-                        if (uri != null)
-                            shareFile();
-                        break;
-                    case R.id.printFile:
-                        if (uri != null)
-                            print(pdfFileName,
-                                    new PdfDocumentAdapter(getApplicationContext()),
-                                    new PrintAttributes.Builder().build());
-                        break;
-                    default:
-                        break;
-
-                }
-
-                return false;
-            }
-        });
         return true;
     }
 

--- a/app/src/main/java/com/gsnathan/pdfviewer/Utils.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/Utils.java
@@ -44,6 +44,7 @@ import java.io.OutputStream;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.ContextCompat;
+
 import io.github.tonnyl.whatsnew.WhatsNew;
 import io.github.tonnyl.whatsnew.item.WhatsNewItem;
 
@@ -56,12 +57,12 @@ public class Utils {
                 new WhatsNewItem("File Manager", "Enable on start of the app", R.drawable.star_icon),
                 new WhatsNewItem("Zoom", "Changed from 3x to 5x", R.drawable.thumbs_icon)
                 );
-        log.setTitleColor(ContextCompat.getColor(context, R.color.colorAccent));
+        log.setTitleColor(Color.BLACK);
         log.setTitleText(context.getResources().getString(R.string.appChangelog));
         log.setButtonText(context.getResources().getString(R.string.buttonLog));
         log.setButtonBackground(ContextCompat.getColor(context, R.color.colorPrimary));
-        log.setButtonTextColor(ContextCompat.getColor(context, R.color.colorAccent));
-        log.setItemTitleColor(ContextCompat.getColor(context, R.color.colorAccent));
+        log.setButtonTextColor(Color.WHITE);
+        log.setItemTitleColor(Color.parseColor("#339999")); // same as icons
         log.setItemContentColor(Color.parseColor("#808080"));
 
         log.show(context.getSupportFragmentManager(), "Log");

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -30,22 +30,6 @@
         android:layout_height="match_parent"
         android:orientation="vertical">
 
-    <com.google.android.material.appbar.AppBarLayout
-        android:id="@+id/my_app_bar_about"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:elevation="4dp"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
-
-            <androidx.appcompat.widget.Toolbar
-                android:id="@+id/toolbar_about"
-                android:layout_width="match_parent"
-                android:layout_height="?attr/actionBarSize"
-                android:theme="@style/ThemeOverlay.AppCompat.ActionBar"
-                app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
-
-    </com.google.android.material.appbar.AppBarLayout>
-
     <ScrollView
         android:id="@+id/scrollView"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -41,7 +41,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"
-        app:itemBackground="?android:attr/colorPrimary"
+        app:itemBackground="@color/cyanea_primary_reference"
         android:minHeight="?android:attr/actionBarSize"
         app:itemIconTint="?menuIconColor"
         app:itemTextColor="?menuIconColor"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -41,8 +41,8 @@ tools:context="com.gsnathan.pdfviewer.MainActivity">
         android:layout_gravity="bottom"
         android:background="?android:attr/colorPrimary"
         android:minHeight="?android:attr/actionBarSize"
-        app:itemIconTint="@color/colorWhite"
-        app:itemTextColor="@color/colorWhite"
+        app:itemIconTint="?menuIconColor"
+        app:itemTextColor="?menuIconColor"
         app:labelVisibilityMode="unlabeled"
         app:menu="@menu/fab_menu" />
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -22,12 +22,14 @@
   ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   ~ SOFTWARE.
   -->
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
-xmlns:app="http://schemas.android.com/apk/res-auto"
-xmlns:tools="http://schemas.android.com/tools"
-android:layout_width="match_parent"
-android:layout_height="match_parent"
-tools:context="com.gsnathan.pdfviewer.MainActivity">
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:clipChildren="false"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="com.gsnathan.pdfviewer.MainActivity">
 
     <com.github.barteksc.pdfviewer.PDFView
         android:id="@+id/pdfView"
@@ -39,7 +41,7 @@ tools:context="com.gsnathan.pdfviewer.MainActivity">
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"
-        android:background="?android:attr/colorPrimary"
+        app:itemBackground="?android:attr/colorPrimary"
         android:minHeight="?android:attr/actionBarSize"
         app:itemIconTint="?menuIconColor"
         app:itemTextColor="?menuIconColor"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -29,6 +29,7 @@
     <color name="colorAccent">#00cc99</color>
     <color name="colorWhite">#ffffff</color>
 
+    <!-- Used for designer preview -->
     <color name="cyanea_primary_reference">#2481a1</color>
     <color name="cyanea_accent_reference">#00cc99</color>
 </resources>


### PR DESCRIPTION
This PR fixes a couple of issues when using themes with a bright primary color, specifically:
- icons in the bottom bar remain white
- About activity title remains white
- bottom app bar has no elevation shadow (and therefore poor contrast with the content) 

<img src="https://user-images.githubusercontent.com/30041551/102695521-34fc3100-4228-11eb-8d97-8a912b7a5afe.png" width="300" />

It also improves colors of Changelog screen a little bit for increased readability: 
<img src="https://user-images.githubusercontent.com/30041551/102695453-c8813200-4227-11eb-8237-896ec5e3b9a5.png" width="300" />