### PR TITLE
Allow zooming out the document

### DIFF
--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -221,7 +221,7 @@ public class MainActivity extends ProgressActivity implements OnPageChangeListen
         @Override
         public void run() {
             if(pdfView != null) {
-                if (pdfView.isZooming())
+                if (pdfView.getZoom() > 1f)
                     hideBottomNavigationView((BottomNavigationView) findViewById(R.id.bottom_navigation));
                 else {
                     showBottomNavigationView((BottomNavigationView) findViewById(R.id.bottom_navigation));
@@ -246,6 +246,7 @@ public class MainActivity extends ProgressActivity implements OnPageChangeListen
 
     void setPdfViewConfiguration() {
         pdfView.useBestQuality(prefManager.getBoolean("quality_pref", false));
+        pdfView.setMinZoom(0.5f);
         pdfView.setMidZoom(2.0f);
         pdfView.setMaxZoom(5.0f);
     }

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -261,7 +261,7 @@ public class MainActivity extends ProgressActivity implements OnPageChangeListen
                 .scrollHandle(new DefaultScrollHandle(this))
                 .spacing(10) // in dp
                 .onPageError(this)
-                .pageFitPolicy(FitPolicy.BOTH)
+                .pageFitPolicy(FitPolicy.WIDTH)
                 .password(PDF_PASSWORD)
                 .swipeHorizontal(prefManager.getBoolean("scroll_pref", false))
                 .autoSpacing(prefManager.getBoolean("scroll_pref", false))


### PR DESCRIPTION
I found myself trying to do that but it didn't work... so I made it work. :smiley: 

Also, since the user can now zoom out, I've changed the page fit policy so that the document is shown at full-width in landscape mode. This way, zoom level is consistent between vertical and landscape mode.