### PR TITLE
Add option to show/hide app in launcher

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,11 +20,6 @@
             android:name=".MainActivity_"
             android:theme="@style/Theme.Cyanea.Light.DarkActionBar">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-            <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -72,7 +67,19 @@
                 <data android:scheme="content" />
                 <data android:mimeType="application/pdf" />
             </intent-filter>
-        </activity> <!-- About -->
+        </activity>
+        <!-- Alias to allow the user to hide the app from launcher -->
+        <activity-alias
+            android:name=".LauncherAlias"
+            android:enabled="true"
+            android:targetActivity=".MainActivity_">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity-alias>
+
         <activity
             android:name=".AboutActivity"
             android:label="About"

--- a/app/src/main/java/com/gsnathan/pdfviewer/SettingsActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/SettingsActivity.java
@@ -1,5 +1,6 @@
 package com.gsnathan.pdfviewer;
 
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -14,6 +15,10 @@ import android.util.TypedValue;
 import android.view.MenuItem;
 
 import androidx.core.app.NavUtils;
+
+import static android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_DISABLED;
+import static android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_ENABLED;
+import static android.content.pm.PackageManager.DONT_KILL_APP;
 
 /**
  * A {@link PreferenceActivity} that presents a set of application settings. On
@@ -76,6 +81,25 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
             }
         });
 
+        findPreference("show_in_launcher").setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                try {
+                    setLauncherAliasState((boolean) newValue);
+                    return true;
+                } catch (Exception ignored) {
+                    return false;
+                }
+            }
+        });
+    }
+
+    private void setLauncherAliasState(boolean enableAlias) {
+        getPackageManager().setComponentEnabledSetting(
+                new ComponentName(this, "com.gsnathan.pdfviewer.LauncherAlias"),
+                enableAlias ? COMPONENT_ENABLED_STATE_ENABLED : COMPONENT_ENABLED_STATE_DISABLED,
+                DONT_KILL_APP
+        );
     }
 
     private void setupActionBar() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,5 +110,6 @@
     <string name="reload">Reload PDF</string>
     <string name="reload_sum">In order to make changes, the PDF must be reloaded.</string>
     <string name="buttonLog">Continue</string>
-
+    <string name="show_in_launcher">Show app in launcher</string>
+    <string name="show_in_launcher_summary">You may need to restart your launcher for this option to take effect</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -2,6 +2,11 @@
 <PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <SwitchPreference
+        android:defaultValue="true"
+        android:title="@string/show_in_launcher"
+        android:summary="@string/show_in_launcher_summary" android:key="show_in_launcher"/>
+
     <PreferenceCategory
         android:title="@string/qualitysettings">
 


### PR DESCRIPTION
This PR adds an option to prevent the app from being shown in launcher, for users (like me) that prefer getting rid of icons that aren't strictly necessary. The other ways to open the app (like selecting a file or a link to a PDF) are unaffected.
As you can see from the screenshot below, the option is set to show the app by default, so that a user must opt-in to hide the icon.
![show_in_launcher](https://user-images.githubusercontent.com/30041551/102692672-25bfb800-4215-11eb-952c-bca26f95a56d.png)


