### PR TITLE
Improve logic for showing/hiding the bottom bar

### DIFF
--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -226,37 +226,33 @@ public class MainActivity extends ProgressActivity {
     }
 
     private void setBottomBarListeners() {
-        bottomNavigation.setOnNavigationItemSelectedListener(new BottomNavigationView.OnNavigationItemSelectedListener() {
-            @Override
-            public boolean onNavigationItemSelected(@NonNull MenuItem item) {
-                switch (item.getItemId()) {
-                    case R.id.pickFile:
-                        pickFile();
-                        break;
-                    case R.id.metaFile:
-                        if (uri != null)
-                            getMeta();
-                        break;
-                    case R.id.unlockFile:
-                        if (uri != null)
-                            unlockPDF();
-                        break;
-                    case R.id.shareFile:
-                        if (uri != null)
-                            shareFile();
-                        break;
-                    case R.id.printFile:
-                        if (uri != null)
-                            print(pdfFileName,
-                                    new PdfDocumentAdapter(getApplicationContext(), uri),
-                                    new PrintAttributes.Builder().build());
-                        break;
-                    default:
-                        break;
-
-                }
-                return false;
+        bottomNavigation.setOnNavigationItemSelectedListener(item -> {
+            switch (item.getItemId()) {
+                case R.id.pickFile:
+                    pickFile();
+                    break;
+                case R.id.metaFile:
+                    if (uri != null)
+                        getMeta();
+                    break;
+                case R.id.unlockFile:
+                    if (uri != null)
+                        unlockPDF();
+                    break;
+                case R.id.shareFile:
+                    if (uri != null)
+                        shareFile();
+                    break;
+                case R.id.printFile:
+                    if (uri != null)
+                        print(pdfFileName,
+                                new PdfDocumentAdapter(getApplicationContext(), uri),
+                                new PrintAttributes.Builder().build());
+                    break;
+                default:
+                    break;
             }
+            return false;
         });
         // Workaround for https://issuetracker.google.com/issues/124153644
         MaterialShapeDrawable viewBackground = (MaterialShapeDrawable) bottomNavigation.getBackground();
@@ -434,13 +430,10 @@ public class MainActivity extends ProgressActivity {
         new AlertDialog.Builder(this)
                 .setTitle(R.string.password)
                 .setView(input)
-                .setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        PDF_PASSWORD = input.getText().toString();
-                        if (uri != null)
-                            displayFromUri(uri);
-                    }
+                .setPositiveButton(R.string.ok, (dialog, which) -> {
+                    PDF_PASSWORD = input.getText().toString();
+                    if (uri != null)
+                        displayFromUri(uri);
                 })
                 .setIcon(R.drawable.lock_icon)
                 .show();
@@ -452,10 +445,7 @@ public class MainActivity extends ProgressActivity {
             AlertDialog.Builder builder = new AlertDialog.Builder(this);
             builder.setTitle(R.string.meta)
                     .setMessage("Title: " + meta.getTitle() + "\n" + "Author: " + meta.getAuthor() + "\n" + "Creation Date: " + meta.getCreationDate())
-                    .setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
-                        public void onClick(DialogInterface dialog, int which) {
-                        }
-                    })
+                    .setPositiveButton(R.string.ok, (dialog, which) -> {})
                     .setIcon(R.drawable.alert_icon)
                     .show();
         }

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -106,7 +106,6 @@ public class MainActivity extends ProgressActivity {
     @ViewById
     BottomNavigationView bottomNavigation;
 
-    @SuppressLint("ClickableViewAccessibility")
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -394,17 +394,12 @@ public class MainActivity extends ProgressActivity {
     public String getFileName(Uri uri) {
         String result = null;
         if (uri.getScheme() != null && uri.getScheme().equals("content")) {
-            Cursor cursor = getContentResolver().query(uri, null, null, null, null);
-            try {
+            try (Cursor cursor = getContentResolver().query(uri, null, null, null, null)) {
                 if (cursor != null && cursor.moveToFirst()) {
                     int indexDisplayName = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
                     if (indexDisplayName != -1) {
                         result = cursor.getString(indexDisplayName);
                     }
-                }
-            } finally {
-                if (cursor != null) {
-                    cursor.close();
                 }
             }
         }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -37,7 +37,7 @@
         android:layout_height="match_parent" />
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
-        android:id="@+id/bottom_navigation"
+        android:id="@+id/bottomNavigation"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"


### PR DESCRIPTION
This PR greatly improves the logic for showing/hiding the bottom navigation bar for an overall better scrolling UX.
Before this PR, the bottom bar was hidden only when the user zoomed the document.
Now it behaves in the following way:
- the bottom bar gets hidden as soon as the user starts scrolling (which includes zooming)
- the user can show/hide the bottom bar with a single tap in any moment
- the bottom bar becomes visible again when the user scrolls at the top of the document (this doesn't work when the scroll handle is used to scroll to the top, I couldn't figure out why)

You can see the new behavior in the video here: https://streamable.com/1mqc23

While I was it, I couldn't refrain from doing some clean-ups to MainActivity in order to take advantage of newer Java features. 😅
I kept clean-up commits very small, so it shouldn't be hard for you to review.