### PR TITLE
Miscellaneous fixes and minor improvements to PDF download feature

### DIFF
--- a/app/src/main/java/com/gsnathan/pdfviewer/DownloadPDFFile.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/DownloadPDFFile.java
@@ -14,6 +14,8 @@ import java.net.URL;
 
 import javax.net.ssl.SSLException;
 
+import static java.net.HttpURLConnection.HTTP_OK;
+
 /**
  * This class is used to get a PDF File from an URL
  */
@@ -28,30 +30,30 @@ public class DownloadPDFFile extends AsyncTask<String, Void, Object> {
 
     @Override
     protected Object doInBackground(String... strings) {
-        File file;
         String url = strings [0];
         String filename = strings[1];
         MainActivity activity = mainActivityWR.get();
+        HttpURLConnection httpConnection = null;
 
         try {
-            URL uri = new URL(url);
-            HttpURLConnection urlConnection = (HttpURLConnection) uri.openConnection();
-            urlConnection.connect();
-            int responseCode = urlConnection.getResponseCode();
-            if (responseCode == 200) {
-                InputStream inputStream = new BufferedInputStream(urlConnection.getInputStream());
-                file = Utils.createFileFromInputStream(activity.getCacheDir(), filename, inputStream);
+            httpConnection = (HttpURLConnection) new URL(url).openConnection();
+            httpConnection.connect();
+            int responseCode = httpConnection.getResponseCode();
+            if (responseCode == HTTP_OK) {
+                InputStream inputStream = new BufferedInputStream(httpConnection.getInputStream());
+                return Utils.createFileFromInputStream(activity.getCacheDir(), filename, inputStream);
             } else {
                 Log.e("DownloadPDFFile", "Error during http request, response code : " + responseCode);
                 return responseCode;
             }
-            urlConnection.disconnect();
         } catch (IOException e) {
             Log.e("DownloadPDFFile", "Error cannot get file at URL : " + url, e);
             return e;
+        } finally {
+            if (httpConnection != null) {
+                httpConnection.disconnect();
+            }
         }
-
-        return file;
     }
 
     @Override

--- a/app/src/main/java/com/gsnathan/pdfviewer/DownloadPDFFile.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/DownloadPDFFile.java
@@ -63,13 +63,13 @@ public class DownloadPDFFile extends AsyncTask<String, Void, Object> {
         if (activity != null) {
             // Manage error
             if (result == null) {
-                Toast.makeText(activity.getApplicationContext(), R.string.toast_io_exception, Toast.LENGTH_SHORT).show();
+                Toast.makeText(activity, R.string.toast_io_exception, Toast.LENGTH_SHORT).show();
             } else if (result instanceof Integer) {
-                Toast.makeText(activity.getApplicationContext(), R.string.toast_http_code_error + String.valueOf(result), Toast.LENGTH_SHORT).show();
+                Toast.makeText(activity, R.string.toast_http_code_error, Toast.LENGTH_SHORT).show();
             } else if (result instanceof SSLException) {
-                Toast.makeText(activity.getApplicationContext(), R.string.toast_ssl_error, Toast.LENGTH_SHORT).show();
+                Toast.makeText(activity, R.string.toast_ssl_error, Toast.LENGTH_SHORT).show();
             } else if (result instanceof IOException) {
-                Toast.makeText(activity.getApplicationContext(), R.string.toast_io_exception, Toast.LENGTH_SHORT).show();
+                Toast.makeText(activity, R.string.toast_io_exception, Toast.LENGTH_SHORT).show();
             } else if (result instanceof File) {
                 activity.saveFileAndDisplay((File) result);
             }

--- a/app/src/main/java/com/gsnathan/pdfviewer/DownloadPDFFile.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/DownloadPDFFile.java
@@ -11,11 +11,8 @@ import java.io.InputStream;
 import java.lang.ref.WeakReference;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.security.cert.Certificate;
 
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLHandshakeException;
-import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLException;
 
 /**
  * This class is used to get a PDF File from an URL
@@ -34,58 +31,23 @@ public class DownloadPDFFile extends AsyncTask<String, Void, Object> {
         File file;
         String url = strings [0];
         String filename = strings[1];
-        InputStream inputStream;
         MainActivity activity = mainActivityWR.get();
-        int responseCode;
 
         try {
             URL uri = new URL(url);
-
-            if (url.startsWith("https")) {
-                Log.i("DownloadPDFFile", "HTTPS CONNECTION");
-                HttpsURLConnection urlConnection = (HttpsURLConnection) uri.openConnection();
-                urlConnection.connect();
-                responseCode = urlConnection.getResponseCode();
-                if (responseCode == 200) {
-                    Certificate[] certs = urlConnection.getServerCertificates();
-                    for (Certificate cert : certs)
-                        Log.i("DownloadPDFFile", "Certificate : " +
-                                "\n - Type : " + cert.getType() +
-                                "\n - Hash Code : " + cert.hashCode() +
-                                "\n - Public Key Algorithm : " + cert.getPublicKey().getAlgorithm() +
-                                "\n - Public Key Format : " + cert.getPublicKey().getFormat()
-                        );
-                    inputStream = new BufferedInputStream(urlConnection.getInputStream());
-                    file = Utils.createFileFromInputStream(activity.getCacheDir(), filename, inputStream);
-                } else {
-                    Log.e("DownloadPDFFile", "Error request https, response code : " + responseCode);
-                    return responseCode;
-                }
-                urlConnection.disconnect();
-
+            HttpURLConnection urlConnection = (HttpURLConnection) uri.openConnection();
+            urlConnection.connect();
+            int responseCode = urlConnection.getResponseCode();
+            if (responseCode == 200) {
+                InputStream inputStream = new BufferedInputStream(urlConnection.getInputStream());
+                file = Utils.createFileFromInputStream(activity.getCacheDir(), filename, inputStream);
             } else {
-                Log.i("DownloadPDFFile", "HTTP CONNECTION");
-                HttpURLConnection urlConnection = (HttpURLConnection) uri.openConnection();
-                urlConnection.connect();
-                responseCode = urlConnection.getResponseCode();
-                if (responseCode == 200) {
-                    inputStream = new BufferedInputStream(urlConnection.getInputStream());
-                    file = Utils.createFileFromInputStream(activity.getCacheDir(), filename, inputStream);
-                } else {
-                    Log.e("DownloadPDFFile", "Error request http, response code : " + responseCode);
-                    return responseCode;
-                }
-                urlConnection.disconnect();
+                Log.e("DownloadPDFFile", "Error during http request, response code : " + responseCode);
+                return responseCode;
             }
-        } catch (SSLPeerUnverifiedException e) {
-            Log.e("DownloadPDFFile", "Error SSL Peer Unverified Exception");
-            return e;
-        } catch (SSLHandshakeException e) {
-            Log.e("DownloadPDFFile", "Error SSL Handshake Exception");
-            return e;
+            urlConnection.disconnect();
         } catch (IOException e) {
-            Log.e("DownloadPDFFile", "Error cannot get file at URL :" + url);
-            e.printStackTrace();
+            Log.e("DownloadPDFFile", "Error cannot get file at URL : " + url, e);
             return e;
         }
 
@@ -102,7 +64,7 @@ public class DownloadPDFFile extends AsyncTask<String, Void, Object> {
                 Toast.makeText(activity.getApplicationContext(), R.string.toast_io_exception, Toast.LENGTH_SHORT).show();
             } else if (result instanceof Integer) {
                 Toast.makeText(activity.getApplicationContext(), R.string.toast_http_code_error + String.valueOf(result), Toast.LENGTH_SHORT).show();
-            } else if (result instanceof SSLPeerUnverifiedException || result instanceof SSLHandshakeException) {
+            } else if (result instanceof SSLException) {
                 Toast.makeText(activity.getApplicationContext(), R.string.toast_ssl_error, Toast.LENGTH_SHORT).show();
             } else if (result instanceof IOException) {
                 Toast.makeText(activity.getApplicationContext(), R.string.toast_io_exception, Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/com/gsnathan/pdfviewer/DownloadPDFFile.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/DownloadPDFFile.java
@@ -63,13 +63,13 @@ public class DownloadPDFFile extends AsyncTask<String, Void, Object> {
         if (activity != null) {
             // Manage error
             if (result == null) {
-                Toast.makeText(activity, R.string.toast_io_exception, Toast.LENGTH_SHORT).show();
+                Toast.makeText(activity, R.string.toast_generic_download_error, Toast.LENGTH_LONG).show();
             } else if (result instanceof Integer) {
-                Toast.makeText(activity, R.string.toast_http_code_error, Toast.LENGTH_SHORT).show();
+                Toast.makeText(activity, R.string.toast_http_code_error, Toast.LENGTH_LONG).show();
             } else if (result instanceof SSLException) {
-                Toast.makeText(activity, R.string.toast_ssl_error, Toast.LENGTH_SHORT).show();
+                Toast.makeText(activity, R.string.toast_ssl_error, Toast.LENGTH_LONG).show();
             } else if (result instanceof IOException) {
-                Toast.makeText(activity, R.string.toast_io_exception, Toast.LENGTH_SHORT).show();
+                Toast.makeText(activity, R.string.toast_generic_download_error, Toast.LENGTH_LONG).show();
             } else if (result instanceof File) {
                 activity.saveFileAndDisplay((File) result);
             }

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -321,33 +321,25 @@ public class MainActivity extends ProgressActivity implements OnPageChangeListen
         }
     }
 
-    void displayFromFile(File file) {
+    private void displayFromFile(File file) {
         setPdfViewConfiguration();
         setPageConfigurationAndLoad(pdfView.fromFile(file));
     }
 
-    public void saveFileAndDisplay(File file) {
-        String filePath = saveTempFileToFile(file);
-        File newFile = new File(filePath);
-        displayFromFile(newFile);
+    void saveFileAndDisplay(File file) {
+        pdfTempFilePath = file.getPath();
+        copyFileToDownloadFolder(file);
+        displayFromFile(file);
     }
 
-    String saveTempFileToFile(File tempFile) {
+    private void copyFileToDownloadFolder(File tempFile) {
         try {
-            // check if the permission to write to external storage is granted
             if (ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
                 InputStream inputStream = new FileInputStream(tempFile);
                 File newFile = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), pdfFileName);
                 OutputStream outputStream = new FileOutputStream(newFile);
                 Utils.readFromInputStreamToOutputStream(inputStream, outputStream);
-
-                return tempFile.getPath();
             } else {
-                // case if the permission hasn't been granted, we will store the pdf in a temp file
-                //store the temporary file path, to be able to save it when permission will be granted
-
-
-                // request for the permission to write to external storage
                 ActivityCompat.requestPermissions(
                         this,
                         new String[]{
@@ -356,14 +348,10 @@ public class MainActivity extends ProgressActivity implements OnPageChangeListen
                         },
                         PERMISSION_WRITE
                 );
-                return pdfTempFilePath;
             }
         } catch (IOException e) {
-            Log.e(TAG, "Error on file : " + e.getMessage());
-            e.printStackTrace();
+            Log.e(TAG, "Error while copying file to download folder", e);
         }
-
-        return null;
     }
 
     void navToSettings() {
@@ -474,7 +462,7 @@ public class MainActivity extends ProgressActivity implements OnPageChangeListen
                 indexPermission = Arrays.asList(permissions).indexOf(Manifest.permission.WRITE_EXTERNAL_STORAGE);
                 if (indexPermission != -1 && grantResults[indexPermission] == PackageManager.PERMISSION_GRANTED) {
                     File file = new File(pdfTempFilePath);
-                    saveTempFileToFile(file);
+                    copyFileToDownloadFolder(file);
                 }
                 break;
         }

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -342,10 +342,7 @@ public class MainActivity extends ProgressActivity implements OnPageChangeListen
             } else {
                 ActivityCompat.requestPermissions(
                         this,
-                        new String[]{
-                                Manifest.permission.WRITE_EXTERNAL_STORAGE,
-                                Manifest.permission.READ_EXTERNAL_STORAGE
-                        },
+                        new String[] { Manifest.permission.WRITE_EXTERNAL_STORAGE },
                         PERMISSION_WRITE
                 );
             }

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -336,9 +336,8 @@ public class MainActivity extends ProgressActivity implements OnPageChangeListen
         try {
             if (ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
                 InputStream inputStream = new FileInputStream(tempFile);
-                File newFile = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), pdfFileName);
-                OutputStream outputStream = new FileOutputStream(newFile);
-                Utils.readFromInputStreamToOutputStream(inputStream, outputStream);
+                File downloadDirectory = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
+                Utils.createFileFromInputStream(downloadDirectory, pdfFileName, inputStream);
             } else {
                 ActivityCompat.requestPermissions(
                         this,

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -460,6 +460,9 @@ public class MainActivity extends ProgressActivity implements OnPageChangeListen
                 if (indexPermission != -1 && grantResults[indexPermission] == PackageManager.PERMISSION_GRANTED) {
                     File file = new File(pdfTempFilePath);
                     copyFileToDownloadFolder(file);
+                    Toast.makeText(this, R.string.saved_to_download, Toast.LENGTH_SHORT).show();
+                } else {
+                    Toast.makeText(this, R.string.save_to_download_failed, Toast.LENGTH_SHORT).show();
                 }
                 break;
         }

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -347,6 +347,7 @@ public class MainActivity extends ProgressActivity implements OnPageChangeListen
             }
         } catch (IOException e) {
             Log.e(TAG, "Error while copying file to download folder", e);
+            Toast.makeText(this, R.string.save_to_download_failed, Toast.LENGTH_SHORT).show();
         }
     }
 

--- a/app/src/main/java/com/gsnathan/pdfviewer/Utils.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/Utils.java
@@ -97,7 +97,7 @@ public class Utils {
         return BuildConfig.VERSION_NAME;
     }
 
-    static void readFromInputStreamToOutputStream (InputStream inputStream, OutputStream outputStream) throws IOException {
+    private static void readFromInputStreamToOutputStream (InputStream inputStream, OutputStream outputStream) throws IOException {
         byte[] buffer = new byte[8 * 1024];
         int bytesRead = inputStream.read(buffer);
         while (bytesRead > -1) {

--- a/app/src/main/java/com/gsnathan/pdfviewer/Utils.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/Utils.java
@@ -109,10 +109,11 @@ public class Utils {
         outputStream.close();
     }
 
-    static File createFileFromInputStream (File cacheDir, String fileName, InputStream inputStream) throws IOException {
-        File file = File.createTempFile(fileName, null, cacheDir);
+    static File createFileFromInputStream(File directory, String fileName, InputStream inputStream) throws IOException {
+        File file = new File(directory, fileName);
+        file.createNewFile();
         OutputStream outputStream = new FileOutputStream(file);
-        Utils.readFromInputStreamToOutputStream(inputStream, outputStream);
+        readFromInputStreamToOutputStream(inputStream, outputStream);
         return file;
     }
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <string name="pick_file">Datei auswählen</string>
     <string name="toast_pick_file_error">Datei konnte nicht ausgewählt werden. Bitte überprüfen Sie Ihren Dateimanager.</string>
-    <string name="toast_http_code_error">Seiten-Ladefehler, http error code : </string>
-    <string name="toast_io_exception">Aus unbekannten Gründen konnte diese Seite nicht geladen werden.</string>
     <string name="toast_ssl_error">Fehler: Gesicherte Verbindung fehlgeschlagen.</string>
     <string name="action_about">Über</string>
     <string name="version">Version</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <string name="pick_file">Choisir un fichier</string>
     <string name="toast_pick_file_error">Impossible de choisir un fichier. Vérifiez dans le navigateur de fichier.</string>
-    <string name="toast_http_code_error">Erreur de chargement de la page, http error code : </string>
-    <string name="toast_io_exception">Pour une raison inconnue, nous ne pouvons pas charger cette page.</string>
     <string name="toast_ssl_error">Échec de la connexion sécurisée.</string>
     <string name="action_about">À propos</string>
     <string name="version">Version</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -26,8 +26,6 @@
     <string name="app_name" translatable="false">Pdf Viewer Plus</string>
     <string name="pick_file">Selecionar arquivo</string>
     <string name="toast_pick_file_error">Não foi possível selecionar um arquivo. Verifique o status do gerenciador de arquivos.</string>
-    <string name="toast_http_code_error">Erro ao carregar a página, código do erro http: </string>
-    <string name="toast_io_exception">Nós não podemos carregar esta página por alguma razão.</string>
     <string name="toast_ssl_error">Falha na conexão segura.</string>
     <string name="action_about">Sobre</string>
     <string name="version">Versão</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -11,8 +11,6 @@
     <!-- Main menu -->
     <string name="pick_file">Выбрать файл</string>
     <string name="toast_pick_file_error">Невозможно выбрать файл. Проверьте ваш файловый менеджер.</string>
-    <string name="toast_http_code_error">Проблема при загрузке страницы, http error code : </string>
-    <string name="toast_io_exception">Мы почему-то не можем загрузить эту страницу.</string>
     <string name="toast_ssl_error">Не удалось установить защищённое соединение.</string>
     <string name="share">Поделиться</string>
     <string name="unlock">Разблокировать защищенный PDF</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,8 @@
     <string name="toast_http_code_error">Remote server responded with an error.</string>
     <string name="toast_generic_download_error">We couldn\'t download this file for some reason.</string>
     <string name="toast_ssl_error">Secure connection failed.</string>
+    <string name="saved_to_download">File saved to Download folder.</string>
+    <string name="save_to_download_failed">Couldn\'t save file to Download folder.</string>
     <string name="action_about">About</string>
     <string name="version">Version</string>
     <string name="intro">Replay Intro</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,7 +27,7 @@
     <string name="pick_file">Pick File</string>
     <string name="toast_pick_file_error">Unable to pick file. Check status of file manager.</string>
     <string name="toast_http_code_error">Remote server responded with an error.</string>
-    <string name="toast_io_exception">We can\'t load this page for some reason.</string>
+    <string name="toast_generic_download_error">We couldn\'t download this file for some reason.</string>
     <string name="toast_ssl_error">Secure connection failed.</string>
     <string name="action_about">About</string>
     <string name="version">Version</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,7 +26,7 @@
     <string name="app_name" translatable="false">Pdf Viewer Plus</string>
     <string name="pick_file">Pick File</string>
     <string name="toast_pick_file_error">Unable to pick file. Check status of file manager.</string>
-    <string name="toast_http_code_error">Problem loading page, http error code : </string>
+    <string name="toast_http_code_error">Remote server responded with an error.</string>
     <string name="toast_io_exception">We can\'t load this page for some reason.</string>
     <string name="toast_ssl_error">Secure connection failed.</string>
     <string name="action_about">About</string>


### PR DESCRIPTION
This PR fixes several issues I encountered while using the PDF download feature, namely:
- string resource ID is printed in the toast instead of actual error message in case of HTTP error response
- if storage access is not granted, the application crashes when opening a PDF link. I've fixed this in e1e99e2 by showing the temporary PDF file in the viewer instead of its copy in Download folder. This way, even if the user denies storage access, the app will continue to run as expected.
I've also added a toast that gets displayed after the user grants or denies write access (d8149e4) to help them understand why that permission was needed.
- if the same file gets redownloaded in temporary folder, overwrite the previous one instead of creating a copy with a different name (700d834). This is a simple way to reduce the number of downloaded files uselessly stored in temporary folder.

While working on this, I got rid of all the duplicate logic for handling HTTPS connections in `DownloadPDFFile` (which was not needed at all) and removed server certificates logging, which IMO does not bring any value.
I've also reworded some download error messages and made them appear for a longer time, so that it's more difficult to miss them. I've removed all the outdated translations for the strings I've changed, to make sure that translators will update them.

As always, I'm open to any feedback on this.