### PR TITLE
Turn on anti-aliasing by default

### DIFF
--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -251,7 +251,7 @@ public class MainActivity extends ProgressActivity {
                 .defaultPage(pageNumber)
                 .onPageChange(this::setCurrentPage)
                 .enableAnnotationRendering(true)
-                .enableAntialiasing(prefManager.getBoolean("alias_pref", false))
+                .enableAntialiasing(prefManager.getBoolean("alias_pref", true))
                 .onTap(this::toggleBottomNavigationVisibility)
                 .onPageScroll(this::toggleBottomNavigationAccordingToPosition)
                 .scrollHandle(new DefaultScrollHandle(this))

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -15,7 +15,7 @@
             android:title="@string/quality" android:key="quality_pref"/>
 
         <SwitchPreference
-            android:defaultValue="false"
+            android:defaultValue="true"
             android:title="@string/alias" android:key="alias_pref"/>
 
     </PreferenceCategory>


### PR DESCRIPTION
In my experience using this app, anti-aliasing makes a big difference in rendering quality - especially with higher-resolution screens - so I find myself always enabling it.
I've made some tests on an old low-tier phone (a 2011 modded S3 Mini) and there is no noticeable performance impact caused by this setting.
I think it is safe to turn this option on for all new users, so that they can get the best possible quality without drawbacks by default.