### PR TITLE
Open downloaded file directly in-memory without saving it to cache folder

### DIFF
--- a/app/src/main/java/com/gsnathan/pdfviewer/DownloadPDFFile.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/DownloadPDFFile.java
@@ -4,10 +4,7 @@ import android.os.AsyncTask;
 import android.util.Log;
 import android.widget.Toast;
 
-import java.io.BufferedInputStream;
-import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.lang.ref.WeakReference;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -30,8 +27,6 @@ public class DownloadPDFFile extends AsyncTask<String, Void, Object> {
     @Override
     protected Object doInBackground(String... strings) {
         String url = strings [0];
-        String filename = strings[1];
-        MainActivity activity = mainActivityWR.get();
         HttpURLConnection httpConnection = null;
 
         try {
@@ -39,8 +34,7 @@ public class DownloadPDFFile extends AsyncTask<String, Void, Object> {
             httpConnection.connect();
             int responseCode = httpConnection.getResponseCode();
             if (responseCode == HTTP_OK) {
-                InputStream inputStream = new BufferedInputStream(httpConnection.getInputStream());
-                return Utils.createFileFromInputStream(activity.getCacheDir(), filename, inputStream);
+                return Utils.readBytesToEnd(httpConnection.getInputStream());
             } else {
                 Log.e("DownloadPDFFile", "Error during http request, response code : " + responseCode);
                 return responseCode;
@@ -70,8 +64,8 @@ public class DownloadPDFFile extends AsyncTask<String, Void, Object> {
                 Toast.makeText(activity, R.string.toast_ssl_error, Toast.LENGTH_LONG).show();
             } else if (result instanceof IOException) {
                 Toast.makeText(activity, R.string.toast_generic_download_error, Toast.LENGTH_LONG).show();
-            } else if (result instanceof File) {
-                activity.saveFileAndDisplay((File) result);
+            } else if (result instanceof byte[]) {
+                activity.saveToFileAndDisplay((byte[]) result);
             }
         }
     }

--- a/app/src/main/java/com/gsnathan/pdfviewer/DownloadPDFFile.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/DownloadPDFFile.java
@@ -26,7 +26,7 @@ public class DownloadPDFFile extends AsyncTask<String, Void, Object> {
 
     @Override
     protected Object doInBackground(String... strings) {
-        String url = strings [0];
+        String url = strings[0];
         HttpURLConnection httpConnection = null;
 
         try {

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -77,11 +77,7 @@ import org.androidannotations.annotations.ViewById;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.Arrays;
 
 @EActivity(R.layout.activity_main)
@@ -174,7 +170,7 @@ public class MainActivity extends CyaneaAppCompatActivity {
 
     private String pdfFileName;
 
-    private String pdfTempFilePath;
+    private byte[] downloadedPdfFileContent;
 
     void shareFile() {
         startActivity(Utils.emailIntent(pdfFileName, "", getResources().getString(R.string.share), uri));
@@ -303,18 +299,17 @@ public class MainActivity extends CyaneaAppCompatActivity {
         progressBar.setVisibility(View.GONE);
     }
 
-    void saveFileAndDisplay(File file) {
-        pdfTempFilePath = file.getPath();
-        copyFileToDownloadFolder(file);
-        configurePdfViewAndLoad(pdfView.fromFile(file));
+    void saveToFileAndDisplay(byte[] pdfFileContent) {
+        downloadedPdfFileContent = pdfFileContent;
+        copyFileToDownloadFolder(pdfFileContent);
+        configurePdfViewAndLoad(pdfView.fromBytes(pdfFileContent));
     }
 
-    private void copyFileToDownloadFolder(File tempFile) {
+    private void copyFileToDownloadFolder(byte[] fileContent) {
         try {
             if (ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
-                InputStream inputStream = new FileInputStream(tempFile);
                 File downloadDirectory = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
-                Utils.createFileFromInputStream(downloadDirectory, pdfFileName, inputStream);
+                Utils.writeBytesToFile(downloadDirectory, pdfFileName, fileContent);
             } else {
                 ActivityCompat.requestPermissions(
                         this,
@@ -408,8 +403,7 @@ public class MainActivity extends CyaneaAppCompatActivity {
             case PERMISSION_WRITE:
                 indexPermission = Arrays.asList(permissions).indexOf(Manifest.permission.WRITE_EXTERNAL_STORAGE);
                 if (indexPermission != -1 && grantResults[indexPermission] == PackageManager.PERMISSION_GRANTED) {
-                    File file = new File(pdfTempFilePath);
-                    copyFileToDownloadFolder(file);
+                    copyFileToDownloadFolder(downloadedPdfFileContent);
                     Toast.makeText(this, R.string.saved_to_download, Toast.LENGTH_SHORT).show();
                 } else {
                     Toast.makeText(this, R.string.save_to_download_failed, Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -289,7 +289,7 @@ public class MainActivity extends CyaneaAppCompatActivity {
             // we will get the pdf asynchronously with the DownloadPDFFile object
             progressBar.setVisibility(View.VISIBLE);
             DownloadPDFFile downloadPDFFile = new DownloadPDFFile(this);
-            downloadPDFFile.execute(uri.toString(), pdfFileName);
+            downloadPDFFile.execute(uri.toString());
         } else {
             configurePdfViewAndLoad(pdfView.fromUri(uri));
         }

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -234,15 +234,12 @@ public class MainActivity extends CyaneaAppCompatActivity {
         viewBackground.setShadowCompatibilityMode(MaterialShapeDrawable.SHADOW_COMPAT_MODE_ALWAYS);
     }
 
-    void setPdfViewConfiguration() {
+    void configurePdfViewAndLoad(PDFView.Configurator viewConfigurator) {
         pdfView.useBestQuality(prefManager.getBoolean("quality_pref", false));
         pdfView.setMinZoom(0.5f);
         pdfView.setMidZoom(2.0f);
         pdfView.setMaxZoom(5.0f);
-    }
-
-    void setPageConfigurationAndLoad(PDFView.Configurator configurator) {
-        configurator
+        viewConfigurator
                 .defaultPage(pageNumber)
                 .onPageChange(this::setCurrentPage)
                 .enableAnnotationRendering(true)
@@ -298,8 +295,7 @@ public class MainActivity extends CyaneaAppCompatActivity {
             DownloadPDFFile downloadPDFFile = new DownloadPDFFile(this);
             downloadPDFFile.execute(uri.toString(), pdfFileName);
         } else {
-            setPdfViewConfiguration();
-            setPageConfigurationAndLoad(pdfView.fromUri(uri));
+            configurePdfViewAndLoad(pdfView.fromUri(uri));
         }
     }
 
@@ -307,15 +303,10 @@ public class MainActivity extends CyaneaAppCompatActivity {
         progressBar.setVisibility(View.GONE);
     }
 
-    private void displayFromFile(File file) {
-        setPdfViewConfiguration();
-        setPageConfigurationAndLoad(pdfView.fromFile(file));
-    }
-
     void saveFileAndDisplay(File file) {
         pdfTempFilePath = file.getPath();
         copyFileToDownloadFolder(file);
-        displayFromFile(file);
+        configurePdfViewAndLoad(pdfView.fromFile(file));
     }
 
     private void copyFileToDownloadFolder(File tempFile) {

--- a/app/src/main/java/com/gsnathan/pdfviewer/Utils.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/Utils.java
@@ -24,26 +24,19 @@
 
 package com.gsnathan.pdfviewer;
 
-import android.app.Activity;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
-import android.graphics.Bitmap;
-import android.graphics.Canvas;
 import android.graphics.Color;
-import android.graphics.drawable.Drawable;
 import android.net.Uri;
-import android.os.Build;
-import android.util.Log;
 
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
+
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
-
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.content.ContextCompat;
 
 import io.github.tonnyl.whatsnew.WhatsNew;
 import io.github.tonnyl.whatsnew.item.WhatsNewItem;
@@ -97,23 +90,20 @@ public class Utils {
         return BuildConfig.VERSION_NAME;
     }
 
-    private static void readFromInputStreamToOutputStream (InputStream inputStream, OutputStream outputStream) throws IOException {
+    static byte[] readBytesToEnd(InputStream inputStream) throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
         byte[] buffer = new byte[8 * 1024];
-        int bytesRead = inputStream.read(buffer);
-        while (bytesRead > -1) {
-            outputStream.write(buffer, 0, bytesRead);
-            bytesRead = inputStream.read(buffer);
+        int bytesRead;
+        while ((bytesRead = inputStream.read(buffer)) != -1) {
+            output.write(buffer, 0, bytesRead);
         }
-
-        outputStream.flush();
-        outputStream.close();
+        return output.toByteArray();
     }
 
-    static File createFileFromInputStream(File directory, String fileName, InputStream inputStream) throws IOException {
+    static void writeBytesToFile(File directory, String fileName, byte[] fileContent) throws IOException {
         File file = new File(directory, fileName);
-        file.createNewFile();
-        OutputStream outputStream = new FileOutputStream(file);
-        readFromInputStreamToOutputStream(inputStream, outputStream);
-        return file;
+        try (FileOutputStream stream = new FileOutputStream(file)) {
+            stream.write(fileContent);
+        }
     }
 }


### PR DESCRIPTION
This PR changes download PDF feature so that the downloaded file is never written to cache folder, but is instead opened directly in-memory.
In this way, there will be no need to clear app cache anymore since nothing is ever written to it.