### PR TITLE
Multi-document support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,7 +71,7 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.appcompat:appcompat:1.3.0-beta01'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 
     // do not update! otherwise dialog buttons will have the wrong color (conflicts with Cyanea)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,8 @@
         android:theme="@style/Theme.Cyanea.Light.DarkActionBar">
 
         <activity
-            android:name=".MainActivity_">
+            android:name=".MainActivity_"
+            android:documentLaunchMode="intoExisting">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -109,11 +109,9 @@ public class MainActivity extends CyaneaAppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        //Kinda not recommended by google but watever
+        // Workaround for https://stackoverflow.com/questions/38200282/
         StrictMode.VmPolicy.Builder builder = new StrictMode.VmPolicy.Builder();
         StrictMode.setVmPolicy(builder.build());
-
-        pdfFileName = "";
 
         prefManager = PreferenceManager.getDefaultSharedPreferences(this);
         onFirstInstall();
@@ -134,22 +132,20 @@ public class MainActivity extends CyaneaAppCompatActivity {
     }
 
     private void onFirstInstall() {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
-        boolean isFirstRun = prefs.getBoolean("FIRSTINSTALL", true);
+        boolean isFirstRun = prefManager.getBoolean("FIRSTINSTALL", true);
         if (isFirstRun) {
             startActivity(new Intent(this, MainIntroActivity.class));
-            SharedPreferences.Editor editor = prefs.edit();
+            SharedPreferences.Editor editor = prefManager.edit();
             editor.putBoolean("FIRSTINSTALL", false);
             editor.apply();
         }
     }
 
     private void onFirstUpdate() {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
-        boolean isFirstRun = prefs.getBoolean(Utils.getAppVersion(), true);
+        boolean isFirstRun = prefManager.getBoolean(Utils.getAppVersion(), true);
         if (isFirstRun) {
             Utils.showLog(this);
-            SharedPreferences.Editor editor = prefs.edit();
+            SharedPreferences.Editor editor = prefManager.edit();
             editor.putBoolean(Utils.getAppVersion(), false);
             editor.apply();
         }
@@ -180,7 +176,7 @@ public class MainActivity extends CyaneaAppCompatActivity {
     @NonConfigurationInstance
     String pdfPassword;
 
-    private String pdfFileName;
+    private String pdfFileName = "";
 
     private byte[] downloadedPdfFileContent;
 

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -25,6 +25,7 @@
 package com.gsnathan.pdfviewer;
 
 import android.Manifest;
+import android.app.ActivityManager;
 import android.app.Dialog;
 import android.content.ActivityNotFoundException;
 import android.content.Intent;
@@ -282,8 +283,9 @@ public class MainActivity extends CyaneaAppCompatActivity {
 
     void displayFromUri(Uri uri) {
         pdfFileName = getFileName(uri);
-        String scheme = uri.getScheme();
+        setTaskDescription(new ActivityManager.TaskDescription(pdfFileName));
 
+        String scheme = uri.getScheme();
         if (scheme != null && scheme.contains("http")) {
             // we will get the pdf asynchronously with the DownloadPDFFile object
             progressBar.setVisibility(View.VISIBLE);

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -90,7 +90,6 @@ public class MainActivity extends CyaneaAppCompatActivity {
     private final static int REQUEST_CODE = 42;
     private final static int PERMISSION_WRITE = 42041;
 
-    private static String PDF_PASSWORD = "";
     private SharedPreferences prefManager;
 
     private boolean isBottomNavigationHidden = false;
@@ -168,6 +167,9 @@ public class MainActivity extends CyaneaAppCompatActivity {
     @NonConfigurationInstance
     Integer pageNumber = 0;
 
+    @NonConfigurationInstance
+    String pdfPassword;
+
     private String pdfFileName;
 
     private byte[] downloadedPdfFileContent;
@@ -243,7 +245,7 @@ public class MainActivity extends CyaneaAppCompatActivity {
                 .spacing(10) // in dp
                 .onPageError((page, err) -> Log.e(TAG, "Cannot load page " + page, err))
                 .pageFitPolicy(FitPolicy.WIDTH)
-                .password(PDF_PASSWORD)
+                .password(pdfPassword)
                 .swipeHorizontal(prefManager.getBoolean("scroll_pref", false))
                 .autoSpacing(prefManager.getBoolean("scroll_pref", false))
                 .pageSnap(prefManager.getBoolean("snap_pref", false))
@@ -378,7 +380,7 @@ public class MainActivity extends CyaneaAppCompatActivity {
                 .setTitle(R.string.password)
                 .setView(input)
                 .setPositiveButton(R.string.ok, (dialog, which) -> {
-                    PDF_PASSWORD = input.getText().toString();
+                    pdfPassword = input.getText().toString();
                     if (uri != null)
                         displayFromUri(uri);
                 })

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -338,8 +338,13 @@ public class MainActivity extends CyaneaAppCompatActivity {
     @OnActivityResult(REQUEST_CODE)
     void onResult(int resultCode, Intent intent) {
         if (resultCode == RESULT_OK) {
-            uri = intent.getData();
-            displayFromUri(uri);
+            if (uri == null) {
+                uri = intent.getData();
+                displayFromUri(uri);
+            } else {
+                intent.setClass(this, MainActivity_.class);
+                startActivity(intent);
+            }
         }
     }
 

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -150,12 +150,6 @@ public class MainActivity extends CyaneaAppCompatActivity {
         }
     }
 
-
-    protected void onNewIntent(Intent intent) {
-        super.onNewIntent(intent);
-        handleIntent(intent);
-    }
-
     private void handleIntent(Intent intent) {
         //Kinda not recommended by google but watever
         StrictMode.VmPolicy.Builder builder = new StrictMode.VmPolicy.Builder();

--- a/app/src/main/java/com/gsnathan/pdfviewer/SettingsActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/SettingsActivity.java
@@ -4,6 +4,7 @@ import android.content.ComponentName;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.util.Log;
 import android.util.TypedValue;
 import android.view.MenuItem;
 import android.view.View;
@@ -32,15 +33,7 @@ public class SettingsActivity extends CyaneaPreferenceActivity {
         setOptionsListTopMargin();
 
         findPreference("reload_pref").setOnPreferenceClickListener(preference -> {
-            try {
-                Uri documentUri = getIntent().getData();
-                Intent intent = new Intent(this, MainActivity_.class);
-                intent.setData(documentUri);
-                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
-                startActivity(intent);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+            reopenDocumentInNewTask();
             return true;
         });
 
@@ -52,6 +45,18 @@ public class SettingsActivity extends CyaneaPreferenceActivity {
                 return false;
             }
         });
+    }
+
+    private void reopenDocumentInNewTask() {
+        try {
+            Uri documentUri = getIntent().getData();
+            Intent intent = new Intent(this, MainActivity_.class);
+            intent.setData(documentUri);
+            intent.addFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK | Intent.FLAG_ACTIVITY_TASK_ON_HOME);
+            startActivity(intent);
+        } catch (Exception e) {
+            Log.e("SettingsActivity", "Reloading PDF failed", e);
+        }
     }
 
     private void setOptionsListTopMargin() {

--- a/app/src/main/java/com/gsnathan/pdfviewer/SettingsActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/SettingsActivity.java
@@ -4,6 +4,7 @@ import android.content.ComponentName;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.preference.Preference;
 import android.util.Log;
 import android.util.TypedValue;
 import android.view.MenuItem;
@@ -32,10 +33,16 @@ public class SettingsActivity extends CyaneaPreferenceActivity {
         addPreferencesFromResource(R.xml.preferences);
         setOptionsListTopMargin();
 
-        findPreference("reload_pref").setOnPreferenceClickListener(preference -> {
-            reopenDocumentInNewTask();
-            return true;
-        });
+        Preference reloadPref = findPreference("reload_pref");
+        Uri documentUri = getIntent().getData();
+        if (documentUri == null) {
+            getPreferenceScreen().removePreference(reloadPref);
+        } else {
+            reloadPref.setOnPreferenceClickListener(preference -> {
+                reopenDocumentInNewTask();
+                return true;
+            });
+        }
 
         findPreference("show_in_launcher").setOnPreferenceChangeListener((preference, newValue) -> {
             try {

--- a/app/src/main/java/com/gsnathan/pdfviewer/SettingsActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/SettingsActivity.java
@@ -12,7 +12,6 @@ import android.view.View;
 
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
-import androidx.core.app.NavUtils;
 
 import com.jaredrummler.cyanea.app.CyaneaPreferenceActivity;
 
@@ -92,7 +91,7 @@ public class SettingsActivity extends CyaneaPreferenceActivity {
         int id = item.getItemId();
         if (id == android.R.id.home) {
             if (!super.onMenuItemSelected(featureId, item)) {
-                NavUtils.navigateUpFromSameTask(this);
+                onBackPressed();
             }
             return true;
         }


### PR DESCRIPTION
With this PR, the app gains the ability to keep multiple PDFs open at the same time, leveraging [`documentLaunchMode` manifest activity attribute](https://developer.android.com/reference/android/R.attr#documentLaunchMode) added in Android Lollipop.
Now every document is opened in its own task (= Recents screen entry), whether it has been opened in-app or from an external app. Also, if the user opens a document that is already present in Recents screen, the corresponding activity gets brought to the foreground instead of launching a new instance of the app.

I had to make some changes to the way MainActivity is reopened when the user clicks on "Reload PDF" in settings. While I was at it, I've hidden the reload button if the user opens Settings while there is no opened document.
I've also taken the opportunity to refactor the way file picker is launched in MainActivity to use the [newer and recommended `registerForActivityResult` AndroidX API](https://developer.android.com/training/basics/intents/result) instead of `startActivityForResult`/`onActivityResult`.

Closes #8
Closes #30 (if I understood that correctly)