### PR TITLE
Restore an useful comment in manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -52,6 +52,7 @@
                 <data android:host="*" />
                 <data android:scheme="file" />
                 <data android:scheme="content" />
+                <!-- Workaround to match files in paths with dots in them, like /sdcard/my.folder/test.pdf -->
                 <data android:pathPattern=".*\\.pdf" />
                 <data android:pathPattern=".*\\..*\\.pdf" />
                 <data android:pathPattern=".*\\..*\\..*\\.pdf" />


### PR DESCRIPTION
While looking into the commit history, I've noticed that a very interesting comment in manifest file went lost at some point.
Since it answered a doubt I was having on the code, I re-added it. Maybe one day someone will find a better solution!