### PR TITLE
Codebase modernization + critical bug fixes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,6 +51,10 @@ android {
         }
     }
 
+    buildFeatures {
+        viewBinding true
+    }
+
     buildTypes {
         release {
             debuggable false

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -70,7 +70,7 @@
             </intent-filter>
         </activity>
 
-        <!-- Alias to allow the user to hide the app from launcher -->
+        <!-- Alias to allow the user to hide the app from launcher on Android < 10 -->
         <activity-alias
             android:name=".LauncherAlias"
             android:enabled="true"

--- a/app/src/main/java/com/gsnathan/pdfviewer/AboutActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/AboutActivity.java
@@ -27,29 +27,27 @@ package com.gsnathan.pdfviewer;
 import android.os.Binder;
 import android.os.Bundle;
 
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
-
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.TextView;
 
 import com.franmontiel.attributionpresenter.AttributionPresenter;
 import com.franmontiel.attributionpresenter.entities.Attribution;
 import com.franmontiel.attributionpresenter.entities.License;
+import com.gsnathan.pdfviewer.databinding.ActivityAboutBinding;
 import com.jaredrummler.cyanea.app.CyaneaAppCompatActivity;
 
 public class AboutActivity extends CyaneaAppCompatActivity {
 
-    TextView versionView;   //shows the version
+    private ActivityAboutBinding viewBinding;
     private final String APP_VERSION_RELEASE = "Version " + Utils.getAppVersion();   //contains Version + the version number
     private final String APP_VERSION_DEBUG = "Version " + Utils.getAppVersion() + "-debug";   //contains Version + the version number + debug
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_about);
-        initUI();
+        viewBinding = ActivityAboutBinding.inflate(getLayoutInflater());
+        setContentView(viewBinding.getRoot());
+        setVersionText();
         setUpToolBar();
     }
 
@@ -58,16 +56,12 @@ public class AboutActivity extends CyaneaAppCompatActivity {
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
     }
 
-    private void initUI() {
-        //initialize the textview
-        versionView = (TextView) findViewById(R.id.versionTextView);
-
+    private void setVersionText() {
         // check if app is debug
         if (BuildConfig.DEBUG) {
-            versionView.setText(APP_VERSION_DEBUG);
-        } else    //if app is release
-        {
-            versionView.setText(APP_VERSION_RELEASE);
+            viewBinding.versionTextView.setText(APP_VERSION_DEBUG);
+        } else {   //if app is release
+            viewBinding.versionTextView.setText(APP_VERSION_RELEASE);
         }
     }
 

--- a/app/src/main/java/com/gsnathan/pdfviewer/AboutActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/AboutActivity.java
@@ -24,7 +24,6 @@
 
 package com.gsnathan.pdfviewer;
 
-import android.os.Binder;
 import android.os.Bundle;
 
 import android.view.MenuItem;
@@ -48,11 +47,6 @@ public class AboutActivity extends CyaneaAppCompatActivity {
         viewBinding = ActivityAboutBinding.inflate(getLayoutInflater());
         setContentView(viewBinding.getRoot());
         setVersionText();
-        setUpToolBar();
-    }
-
-    private void setUpToolBar() {
-        Binder.clearCallingIdentity();
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
     }
 

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -103,28 +103,26 @@ public class MainActivity extends CyaneaAppCompatActivity {
         viewBinding = ActivityMainBinding.inflate(getLayoutInflater());
         setContentView(viewBinding.getRoot());
 
+        viewBinding.pdfView.setBackgroundColor(Color.LTGRAY);
+        Constants.THUMBNAIL_RATIO = 1f;
+        setBottomBarListeners();
+
         // Workaround for https://stackoverflow.com/questions/38200282/
         StrictMode.VmPolicy.Builder builder = new StrictMode.VmPolicy.Builder();
         StrictMode.setVmPolicy(builder.build());
 
         prefManager = PreferenceManager.getDefaultSharedPreferences(this);
+        mgr = (PrintManager) getSystemService(PRINT_SERVICE);
         onFirstInstall();
         onFirstUpdate();
-        uri = readUriFromIntent(getIntent());
 
+        uri = readUriFromIntent(getIntent());
         if (uri == null) {
             pickFile();
-        }
-
-        mgr = (PrintManager) getSystemService(PRINT_SERVICE);
-
-        viewBinding.pdfView.setBackgroundColor(Color.LTGRAY);
-        Constants.THUMBNAIL_RATIO = 1f;
-        if (uri != null) {
+            setTitle("");
+        } else {
             displayFromUri(uri);
         }
-        setTitle(pdfFileName);
-        setBottomBarListeners();
     }
 
     private void onFirstInstall() {
@@ -290,6 +288,7 @@ public class MainActivity extends CyaneaAppCompatActivity {
 
     void displayFromUri(Uri uri) {
         pdfFileName = getFileName(uri);
+        setTitle(pdfFileName);
         setTaskDescription(new ActivityManager.TaskDescription(pdfFileName));
 
         String scheme = uri.getScheme();

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -81,7 +81,7 @@ public class MainActivity extends CyaneaAppCompatActivity {
 
     private static final String TAG = MainActivity.class.getSimpleName();
 
-    private PrintManager mgr = null;
+    private PrintManager mgr;
     private SharedPreferences prefManager;
 
     private boolean isBottomNavigationHidden = false;

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -116,7 +116,7 @@ public class MainActivity extends CyaneaAppCompatActivity {
         onFirstInstall();
         onFirstUpdate();
 
-        uri = readUriFromIntent(getIntent());
+        readUriFromIntent(getIntent());
         if (uri == null) {
             pickFile();
             setTitle("");
@@ -145,20 +145,21 @@ public class MainActivity extends CyaneaAppCompatActivity {
         }
     }
 
-    private Uri readUriFromIntent(Intent intent) {
-        Uri uri = intent.getData();
-        if (uri == null) {
-            return null;
+    private void readUriFromIntent(Intent intent) {
+        Uri intentUri = intent.getData();
+        if (intentUri == null) {
+            return;
         }
 
         // Happens when the content provider URI used to open the document expires
-        if ("content".equals(uri.getScheme()) &&
-            checkCallingOrSelfUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION) == PERMISSION_DENIED) {
-            Log.w(TAG, "No read permission for URI " + uri);
-            return null;
+        if ("content".equals(intentUri.getScheme()) &&
+            checkCallingOrSelfUriPermission(intentUri, Intent.FLAG_GRANT_READ_URI_PERMISSION) == PERMISSION_DENIED) {
+            Log.w(TAG, "No read permission for URI " + intentUri);
+            uri = null;
+            return;
         }
 
-        return uri;
+        uri = intentUri;
     }
 
     @NonConfigurationInstance

--- a/app/src/main/java/com/gsnathan/pdfviewer/SettingsActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/SettingsActivity.java
@@ -3,6 +3,7 @@ package com.gsnathan.pdfviewer;
 import android.content.ComponentName;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.util.Log;
@@ -30,8 +31,12 @@ public class SettingsActivity extends CyaneaPreferenceActivity {
 
         setupActionBar();
         addPreferencesFromResource(R.xml.preferences);
-        setOptionsListTopMargin();
 
+        setupReloadPdfPreference();
+        setupShowInLauncherPreference();
+    }
+
+    private void setupReloadPdfPreference() {
         Preference reloadPref = findPreference("reload_pref");
         Uri documentUri = getIntent().getData();
         if (documentUri == null) {
@@ -42,15 +47,25 @@ public class SettingsActivity extends CyaneaPreferenceActivity {
                 return true;
             });
         }
+    }
 
-        findPreference("show_in_launcher").setOnPreferenceChangeListener((preference, newValue) -> {
-            try {
-                setLauncherAliasState((boolean) newValue);
-                return true;
-            } catch (Exception ignored) {
-                return false;
-            }
-        });
+    private void setupShowInLauncherPreference() {
+        Preference showInLauncherPref = findPreference("show_in_launcher");
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            // Starting from Android Q it is not possible anymore to hide the app from launcher
+            // See https://developer.android.com/reference/android/content/pm/LauncherApps#getActivityList(java.lang.String,%20android.os.UserHandle)
+            getPreferenceScreen().removePreference(showInLauncherPref);
+        } else {
+            setOptionsListTopMargin();
+            showInLauncherPref.setOnPreferenceChangeListener((preference, newValue) -> {
+                try {
+                    setLauncherAliasState((boolean) newValue);
+                    return true;
+                } catch (Exception ignored) {
+                    return false;
+                }
+            });
+        }
     }
 
     private void reopenDocumentInNewTask() {

--- a/app/src/main/java/com/gsnathan/pdfviewer/Utils.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/Utils.java
@@ -45,9 +45,10 @@ public class Utils {
 
     static void showLog(AppCompatActivity context) {
         WhatsNew log = WhatsNew.newInstance(
-                new WhatsNewItem("Bugs", "A bunch of bug fixes.", R.drawable.star_icon),
-                new WhatsNewItem("Scroll", "Lots of scrolling improvements", R.drawable.star_icon)
-                );
+                new WhatsNewItem("Multi-document mode", "You can now open multiple documents at the same time!", R.drawable.star_icon),
+                new WhatsNewItem("Optimizations and UI improvements", "Especially when opening files from the Internet.", R.drawable.star_icon),
+                new WhatsNewItem("Bugs", "A bunch of bug fixes.", R.drawable.star_icon)
+        );
         log.setTitleColor(Color.BLACK);
         log.setTitleText(context.getResources().getString(R.string.appChangelog));
         log.setButtonText(context.getResources().getString(R.string.buttonLog));


### PR DESCRIPTION
In this PR I made some refactorings to leverage newer Android APIs and build features, namely:
- **view binding**: modern, safer and more performant replacement for `findViewById` (and `@ViewById` annotation). A nice extra benefit of this change is that MainActivity's onCreate() is no longer split between onCreate() and afterViews(), since we do the inflation manually.
- **`registerForActivityResult()` API** for requesting write permission, that we already use for opening file picker

I have also fixed two bugs:
- a **regression** introduced in multi-document PR (#88), that causes MainActivity to lose state on rotation when a file has been opened inside the app
- I have removed the option "Show app in launcher" on Android 10+ devices, since it does not work due to an Android change that we cannot workaround

If you want to push a 3.5.1 hotfix version for the regression, I have edited the changelog to mention the addition of multi-document mode, since it was a feature requested by several people (and I imagine that not all of them keep up with the latest developments on GitHub).

Fixes #93 