### PR TITLE
Improved handling of errors while opening a PDF

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -84,7 +84,7 @@
 
         <activity
             android:name=".AboutActivity"
-            android:label="About"
+            android:label="@string/action_about"
             android:parentActivityName=".MainActivity_" />
 
         <activity
@@ -94,7 +94,7 @@
 
         <activity
             android:name=".SettingsActivity"
-            android:label="Settings"
+            android:label="@string/settings"
             android:parentActivityName=".MainActivity_" />
     </application>
 

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -66,6 +66,7 @@ import com.gsnathan.pdfviewer.databinding.ActivityMainBinding;
 import com.jaredrummler.cyanea.app.CyaneaAppCompatActivity;
 import com.jaredrummler.cyanea.prefs.CyaneaSettingsActivity;
 import com.shockwave.pdfium.PdfDocument;
+import com.shockwave.pdfium.PdfPasswordException;
 
 import org.androidannotations.annotations.EActivity;
 import org.androidannotations.annotations.NonConfigurationInstance;
@@ -247,6 +248,7 @@ public class MainActivity extends CyaneaAppCompatActivity {
                 .onPageScroll(this::toggleBottomNavigationAccordingToPosition)
                 .scrollHandle(new DefaultScrollHandle(this))
                 .spacing(10) // in dp
+                .onError(this::handleFileOpeningError)
                 .onPageError((page, err) -> Log.e(TAG, "Cannot load page " + page, err))
                 .pageFitPolicy(FitPolicy.WIDTH)
                 .password(pdfPassword)
@@ -255,6 +257,15 @@ public class MainActivity extends CyaneaAppCompatActivity {
                 .pageSnap(prefManager.getBoolean("snap_pref", false))
                 .pageFling(prefManager.getBoolean("fling_pref", false))
                 .load();
+    }
+
+    private void handleFileOpeningError(Throwable exception) {
+        if (exception instanceof PdfPasswordException) {
+            unlockPDF();
+        } else {
+            Toast.makeText(this, R.string.file_opening_error, Toast.LENGTH_LONG).show();
+            Log.e(TAG, "Error when opening file", exception);
+        }
     }
 
     private void toggleBottomNavigationAccordingToPosition(int page, float positionOffset) {

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -216,10 +216,6 @@ public class MainActivity extends CyaneaAppCompatActivity {
                     if (uri != null)
                         showPdfMetaDialog();
                     break;
-                case R.id.unlockFile:
-                    if (uri != null)
-                        unlockPDF();
-                    break;
                 case R.id.shareFile:
                     if (uri != null)
                         shareFile();

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -40,13 +40,11 @@ import android.os.StrictMode;
 import android.preference.PreferenceManager;
 import android.print.PrintManager;
 import android.provider.OpenableColumns;
-import android.text.InputType;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
-import android.widget.EditText;
 import android.widget.Toast;
 
 import androidx.activity.result.ActivityResultLauncher;
@@ -258,7 +256,7 @@ public class MainActivity extends CyaneaAppCompatActivity {
 
     private void handleFileOpeningError(Throwable exception) {
         if (exception instanceof PdfPasswordException) {
-            unlockPDF();
+            askForPdfPassword();
         } else {
             Toast.makeText(this, R.string.file_opening_error, Toast.LENGTH_LONG).show();
             Log.e(TAG, "Error when opening file", exception);
@@ -384,7 +382,7 @@ public class MainActivity extends CyaneaAppCompatActivity {
         mgr.print(pdfFileName, new PdfDocumentAdapter(this, uri), null);
     }
 
-    void unlockPDF() {
+    void askForPdfPassword() {
         PasswordDialogBinding dialogBinding = PasswordDialogBinding.inflate(getLayoutInflater());
         AlertDialog alert = new AlertDialog.Builder(this)
                 .setTitle(R.string.protected_pdf)

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -63,6 +63,7 @@ import com.github.barteksc.pdfviewer.scroll.DefaultScrollHandle;
 import com.github.barteksc.pdfviewer.util.Constants;
 import com.github.barteksc.pdfviewer.util.FitPolicy;
 import com.gsnathan.pdfviewer.databinding.ActivityMainBinding;
+import com.gsnathan.pdfviewer.databinding.PasswordDialogBinding;
 import com.jaredrummler.cyanea.app.CyaneaAppCompatActivity;
 import com.jaredrummler.cyanea.prefs.CyaneaSettingsActivity;
 import com.shockwave.pdfium.PdfDocument;
@@ -388,21 +389,19 @@ public class MainActivity extends CyaneaAppCompatActivity {
     }
 
     void unlockPDF() {
-
-        final EditText input = new EditText(this);
-        input.setPadding(19, 19, 19, 19);
-        input.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
-
-        new AlertDialog.Builder(this)
-                .setTitle(R.string.password)
-                .setView(input)
+        PasswordDialogBinding dialogBinding = PasswordDialogBinding.inflate(getLayoutInflater());
+        AlertDialog alert = new AlertDialog.Builder(this)
+                .setTitle(R.string.protected_pdf)
+                .setView(dialogBinding.getRoot())
                 .setPositiveButton(R.string.ok, (dialog, which) -> {
-                    pdfPassword = input.getText().toString();
+                    pdfPassword = dialogBinding.passwordInput.getText().toString();
                     if (uri != null)
                         displayFromUri(uri);
                 })
                 .setIcon(R.drawable.lock_icon)
-                .show();
+                .create();
+        alert.setCanceledOnTouchOutside(false);
+        alert.show();
     }
 
     void showPdfMetaDialog() {

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -395,8 +395,7 @@ public class MainActivity extends CyaneaAppCompatActivity {
                 .setView(dialogBinding.getRoot())
                 .setPositiveButton(R.string.ok, (dialog, which) -> {
                     pdfPassword = dialogBinding.passwordInput.getText().toString();
-                    if (uri != null)
-                        displayFromUri(uri);
+                    displayFromUri(uri);
                 })
                 .setIcon(R.drawable.lock_icon)
                 .create();

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -256,6 +256,10 @@ public class MainActivity extends CyaneaAppCompatActivity {
 
     private void handleFileOpeningError(Throwable exception) {
         if (exception instanceof PdfPasswordException) {
+            if (pdfPassword != null) {
+                Toast.makeText(this, R.string.wrong_password, Toast.LENGTH_SHORT).show();
+                pdfPassword = null;  // prevent the toast from being shown again if the user rotates the screen
+            }
             askForPdfPassword();
         } else {
             Toast.makeText(this, R.string.file_opening_error, Toast.LENGTH_LONG).show();

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -185,7 +185,7 @@ public class MainActivity extends CyaneaAppCompatActivity {
             return;
         }
 
-        if (uri == null) {
+        if (uri == null || selectedDocumentUri.equals(uri)) {
             uri = selectedDocumentUri;
             displayFromUri(uri);
         } else {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -51,7 +51,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"
-        app:itemBackground="@color/cyanea_primary_reference"
+        android:background="@color/cyanea_primary_reference"
         android:minHeight="?android:attr/actionBarSize"
         app:itemIconTint="?menuIconColor"
         app:itemTextColor="?menuIconColor"

--- a/app/src/main/res/layout/password_dialog.xml
+++ b/app/src/main/res/layout/password_dialog.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingHorizontal="24dp">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_marginHorizontal="2dp"
+        android:labelFor="@+id/passwordInput"
+        android:textSize="16sp"
+        android:textColor="?android:textColorPrimary"
+        android:text="@string/enter_password"/>
+
+    <EditText
+        android:id="@+id/passwordInput"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:inputType="textPassword"
+        android:importantForAutofill="no" />
+</LinearLayout>

--- a/app/src/main/res/menu/fab_menu.xml
+++ b/app/src/main/res/menu/fab_menu.xml
@@ -17,13 +17,6 @@
         app:showAsAction="always" />
 
     <item
-        android:id="@+id/unlockFile"
-        android:icon="@drawable/lock_icon"
-        android:title="@string/unlock"
-        android:orderInCategory="3"
-        app:showAsAction="always" />
-
-    <item
         android:id="@+id/shareFile"
         android:icon="@drawable/share_icon"
         android:title="@string/share"

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -92,7 +92,6 @@
 
     <string name="pref_colored_navigation_bar_title">Barva navigační lišty</string>
     <string name="pref_colored_navigation_bar_summary">Primární barva navigační lišty</string>
-    <string name="unlock">Odemknout Zabezpečený soubor</string>
     <string name="meta">Informace o souboru</string>
     <string name="quality">Vysoká kvalita vykreslování</string>
     <string name="settings">Nastavení</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -92,7 +92,6 @@
 
     <string name="pref_colored_navigation_bar_title">Barva navigační lišty</string>
     <string name="pref_colored_navigation_bar_summary">Primární barva navigační lišty</string>
-    <string name="password">Heslo</string>
     <string name="unlock">Odemknout Zabezpečený soubor</string>
     <string name="meta">Informace o souboru</string>
     <string name="quality">Vysoká kvalita vykreslování</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -38,7 +38,6 @@
     <string name="pref_category_appearance">Erscheinungsbild</string>
     <string name="pref_colored_navigation_bar_title">Farbe der Navigationsleiste</string>
     <string name="pref_colored_navigation_bar_summary">Hauptfarbe auf die Navigationsleiste anwenden</string>
-    <string name="unlock">Gesicherte PDF-Datei entsperren</string>
     <string name="meta">Dateiinfo</string>
     <string name="quality">Wiedergabe in hoher Qualität</string>
     <string name="settings">Einstellungen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -38,7 +38,6 @@
     <string name="pref_category_appearance">Erscheinungsbild</string>
     <string name="pref_colored_navigation_bar_title">Farbe der Navigationsleiste</string>
     <string name="pref_colored_navigation_bar_summary">Hauptfarbe auf die Navigationsleiste anwenden</string>
-    <string name="password">Passwort</string>
     <string name="unlock">Gesicherte PDF-Datei entsperren</string>
     <string name="meta">Dateiinfo</string>
     <string name="quality">Wiedergabe in hoher Qualität</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -97,7 +97,6 @@
 
     <string name="pref_colored_navigation_bar_title">Color de la barra de navegación</string>
     <string name="pref_colored_navigation_bar_summary">Aplica el color primario a la barra de navegación.</string>
-    <string name="unlock">Desbloquear PDF protegido</string>
     <string name="meta">Información</string>
     <string name="quality">Renderizado de alta calidad</string>
     <string name="settings">Configuración</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -97,7 +97,6 @@
 
     <string name="pref_colored_navigation_bar_title">Color de la barra de navegación</string>
     <string name="pref_colored_navigation_bar_summary">Aplica el color primario a la barra de navegación.</string>
-    <string name="password">Contraseña</string>
     <string name="unlock">Desbloquear PDF protegido</string>
     <string name="meta">Información</string>
     <string name="quality">Renderizado de alta calidad</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -42,7 +42,6 @@
     <string name="pref_category_appearance">Apparence</string>
     <string name="pref_colored_navigation_bar_title">Couleur de la barre de navigation</string>
     <string name="pref_colored_navigation_bar_summary">Appliquer la couleur principale à la barre de navigation</string>
-    <string name="password">Mot de passe</string>
     <string name="unlock">Déverrouiller un PDF sécurisé</string>
     <string name="meta">Info sur le fichier</string>
     <string name="quality">Rendu en haute qualité</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -42,7 +42,6 @@
     <string name="pref_category_appearance">Apparence</string>
     <string name="pref_colored_navigation_bar_title">Couleur de la barre de navigation</string>
     <string name="pref_colored_navigation_bar_summary">Appliquer la couleur principale à la barre de navigation</string>
-    <string name="unlock">Déverrouiller un PDF sécurisé</string>
     <string name="meta">Info sur le fichier</string>
     <string name="quality">Rendu en haute qualité</string>
     <string name="settings">Préférences</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -53,7 +53,6 @@
 
     <string name="pref_colored_navigation_bar_title">Colore della barra di navigazione</string>
     <string name="pref_colored_navigation_bar_summary">Applica il colore primario alla barra di navigazione</string>
-    <string name="unlock">Sblocca PDF protetto</string>
     <string name="meta">Informazioni sul file</string>
     <string name="quality">Rendering di alta qualità</string>
     <string name="settings">Impostazioni</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -53,7 +53,6 @@
 
     <string name="pref_colored_navigation_bar_title">Colore della barra di navigazione</string>
     <string name="pref_colored_navigation_bar_summary">Applica il colore primario alla barra di navigazione</string>
-    <string name="password">Password</string>
     <string name="unlock">Sblocca PDF protetto</string>
     <string name="meta">Informazioni sul file</string>
     <string name="quality">Rendering di alta qualità</string>
@@ -75,5 +74,7 @@
     <string name="pdf_title">Titolo: %1$s</string>
     <string name="pdf_author">Autore: %1$s</string>
     <string name="pdf_creation_date">Data di creazione: %1$s</string>
-    
+    <string name="file_opening_error">Si è verificato un errore durante l\'apertura del file.</string>
+    <string name="protected_pdf">PDF protetto</string>
+    <string name="enter_password">Inserisci la password corretta per aprire il documento:</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -76,4 +76,5 @@
     <string name="file_opening_error">Si è verificato un errore durante l\'apertura del file.</string>
     <string name="protected_pdf">PDF protetto</string>
     <string name="enter_password">Inserisci la password corretta per aprire il documento:</string>
+    <string name="wrong_password">Password errata.</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -93,7 +93,6 @@
 
     <string name="pref_colored_navigation_bar_title">Cor da barra de navegação</string>
     <string name="pref_colored_navigation_bar_summary">Aplicar a cor primária à barra de navegação</string>
-    <string name="unlock">Desbloquear PDF seguro</string>
     <string name="meta">Informações do arquivo</string>
     <string name="quality">Renderização em alta qualidade</string>
     <string name="settings">Configurações</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -93,7 +93,6 @@
 
     <string name="pref_colored_navigation_bar_title">Cor da barra de navegação</string>
     <string name="pref_colored_navigation_bar_summary">Aplicar a cor primária à barra de navegação</string>
-    <string name="password">Senha</string>
     <string name="unlock">Desbloquear PDF seguro</string>
     <string name="meta">Informações do arquivo</string>
     <string name="quality">Renderização em alta qualidade</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -13,7 +13,6 @@
     <string name="toast_pick_file_error">Невозможно выбрать файл. Проверьте ваш файловый менеджер.</string>
     <string name="toast_ssl_error">Не удалось установить защищённое соединение.</string>
     <string name="share">Поделиться</string>
-    <string name="unlock">Разблокировать защищенный PDF</string>
     <string name="meta">Информация о файле</string>
     <string name="print">Печать</string>
 

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -14,7 +14,6 @@
     <string name="toast_ssl_error">Не удалось установить защищённое соединение.</string>
     <string name="share">Поделиться</string>
     <string name="unlock">Разблокировать защищенный PDF</string>
-    <string name="password">Пароль</string>
     <string name="meta">Информация о файле</string>
     <string name="print">Печать</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,4 +120,5 @@
     <string name="file_opening_error">An error occurred while opening the file.</string>
     <string name="protected_pdf">Protected PDF</string>
     <string name="enter_password">Enter the correct password to open the document:</string>
+    <string name="wrong_password">Wrong password.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,7 +97,6 @@
 
     <string name="pref_colored_navigation_bar_title">Navigation bar color</string>
     <string name="pref_colored_navigation_bar_summary">Apply the primary color to the navigation bar</string>
-    <string name="unlock">Unlock Secure PDF</string>
     <string name="meta">File Info</string>
     <string name="quality">High Quality Rendering</string>
     <string name="settings">Settings</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,7 +97,6 @@
 
     <string name="pref_colored_navigation_bar_title">Navigation bar color</string>
     <string name="pref_colored_navigation_bar_summary">Apply the primary color to the navigation bar</string>
-    <string name="password">Password</string>
     <string name="unlock">Unlock Secure PDF</string>
     <string name="meta">File Info</string>
     <string name="quality">High Quality Rendering</string>
@@ -120,4 +119,6 @@
     <string name="pdf_author">Author: %1$s</string>
     <string name="pdf_creation_date">Creation Date: %1$s</string>
     <string name="file_opening_error">An error occurred while opening the file.</string>
+    <string name="protected_pdf">Protected PDF</string>
+    <string name="enter_password">Enter the correct password to open the document:</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -119,4 +119,5 @@
     <string name="pdf_title">Title: %1$s</string>
     <string name="pdf_author">Author: %1$s</string>
     <string name="pdf_creation_date">Creation Date: %1$s</string>
+    <string name="file_opening_error">An error occurred while opening the file.</string>
 </resources>


### PR DESCRIPTION
This PR aims to make it clear to the user when opening the PDF fails due to an error or the document is protected by a password.
Currently, in both these scenarios the app shows only a blank screen without any indication.
With these changes, behavior changes as follows:
- if there is an error while opening the PDF, a toast with a generic error message is displayed
- if the PDF is protected, the user is asked to provide a password through the usual dialog (which has been revamped). If the entered password is wrong, a "Wrong password" toast is shown and the password prompt is displayed again

Since this last change makes the "Unlock PDF" button in the bottom bar useless, I removed it and made more difficult to accidentally dismiss the password request dialog.
Lastly, I've tweaked file opening behavior so that, in case the user tries to reopen the same document, the app does not launch the same document in a new activity (subtle bug introduced with #88 and reported in #98).

Fixes #23

**Bonus:** I fixed a regression that caused ripple effect not to be rendered when pressing bottom bar buttons. Also, I found out that certain activity titles weren't using translated strings.