### PR TITLE
Reload document automatically after closing settings

### DIFF
--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -186,7 +186,10 @@ public class MainActivity extends CyaneaAppCompatActivity {
 
     private final ActivityResultLauncher<Intent> settingsLauncher = registerForActivityResult(
             new StartActivityForResult(),
-            result -> displayFromUri(uri)
+            result -> {
+                if (uri != null)
+                    displayFromUri(uri);
+            }
     );
 
     void shareFile() {

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -34,7 +34,6 @@ import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.graphics.Color;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.StrictMode;
@@ -54,7 +53,6 @@ import androidx.activity.result.contract.ActivityResultContracts.RequestPermissi
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.DialogFragment;
@@ -115,11 +113,6 @@ public class MainActivity extends CyaneaAppCompatActivity {
         StrictMode.setVmPolicy(builder.build());
 
         prefManager = PreferenceManager.getDefaultSharedPreferences(this);
-
-        if (prefManager.getBoolean("pdftheme_pref", false) == false)
-            viewBinding.pdfView.setBackgroundColor(Color.LTGRAY);
-        else
-            viewBinding.pdfView.setBackgroundColor(0xFF212121);
 
         mgr = (PrintManager) getSystemService(PRINT_SERVICE);
         onFirstInstall();
@@ -246,6 +239,11 @@ public class MainActivity extends CyaneaAppCompatActivity {
     }
 
     void configurePdfViewAndLoad(PDFView.Configurator viewConfigurator) {
+        if (!prefManager.getBoolean("pdftheme_pref", false)) {
+            viewBinding.pdfView.setBackgroundColor(Color.LTGRAY);
+        } else {
+            viewBinding.pdfView.setBackgroundColor(0xFF212121);
+        }
         viewBinding.pdfView.useBestQuality(prefManager.getBoolean("quality_pref", false));
         viewBinding.pdfView.setMinZoom(0.5f);
         viewBinding.pdfView.setMidZoom(2.0f);

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -51,6 +51,7 @@ import android.widget.Toast;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts.OpenDocument;
 import androidx.activity.result.contract.ActivityResultContracts.RequestPermission;
+import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
@@ -182,6 +183,11 @@ public class MainActivity extends CyaneaAppCompatActivity {
     private String pdfFileName = "";
 
     private byte[] downloadedPdfFileContent;
+
+    private final ActivityResultLauncher<Intent> settingsLauncher = registerForActivityResult(
+            new StartActivityForResult(),
+            result -> displayFromUri(uri)
+    );
 
     void shareFile() {
         startActivity(Utils.emailIntent(pdfFileName, "", getResources().getString(R.string.share), uri));
@@ -362,9 +368,7 @@ public class MainActivity extends CyaneaAppCompatActivity {
     }
 
     void navToSettings() {
-        Intent intent = new Intent(this, SettingsActivity.class);
-        intent.setData(uri);
-        startActivity(intent);
+        settingsLauncher.launch(new Intent(this, SettingsActivity.class));
     }
 
     private void setCurrentPage(int page, int pageCount) {

--- a/app/src/main/java/com/gsnathan/pdfviewer/SettingsActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/SettingsActivity.java
@@ -31,22 +31,7 @@ public class SettingsActivity extends CyaneaPreferenceActivity {
 
         setupActionBar();
         addPreferencesFromResource(R.xml.preferences);
-
-        setupReloadPdfPreference();
         setupShowInLauncherPreference();
-    }
-
-    private void setupReloadPdfPreference() {
-        Preference reloadPref = findPreference("reload_pref");
-        Uri documentUri = getIntent().getData();
-        if (documentUri == null) {
-            getPreferenceScreen().removePreference(reloadPref);
-        } else {
-            reloadPref.setOnPreferenceClickListener(preference -> {
-                reopenDocumentInNewTask();
-                return true;
-            });
-        }
     }
 
     private void setupShowInLauncherPreference() {
@@ -65,18 +50,6 @@ public class SettingsActivity extends CyaneaPreferenceActivity {
                     return false;
                 }
             });
-        }
-    }
-
-    private void reopenDocumentInNewTask() {
-        try {
-            Uri documentUri = getIntent().getData();
-            Intent intent = new Intent(this, MainActivity_.class);
-            intent.setData(documentUri);
-            intent.addFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK | Intent.FLAG_ACTIVITY_TASK_ON_HOME);
-            startActivity(intent);
-        } catch (Exception e) {
-            Log.e("SettingsActivity", "Reloading PDF failed", e);
         }
     }
 

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -102,8 +102,6 @@
     <string name="qualitysettings">Kvalita</string>
     <string name="scrollsettings">Pohyb v dokumentu</string>
     <string name="title_activity_settings">Nastavení</string>
-    <string name="reload">Znovu-načtení PDF</string>
-    <string name="reload_sum">Pro uplatnění změn je nutno soubor znovu načíst.</string>
     <string name="buttonLog">Pokračovat</string>
 
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -54,10 +54,6 @@
         SOFTWARE.
     </string>
 
-    <string name="notice">
-        Drazí uživatelé,\n\nPdf Viewer Plus je nyní k dispozici i přes F-Droid!
-    </string>
-
     <string name="appChangelog">Změnové záznamy</string>
     <string name="ok">Ok</string>
     <string name="title_permission">Oprávnění k úložišti</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -12,7 +12,6 @@
     <string name="description__intro">Ein einfacher Dokumentenbetrachter für Pdf-Dateien.</string>
     <string name="myLicense">Lizenz</string>
     <string name="privacy">Datenschutz-Bestimmungen</string>
-    <string name="notice">Liebe Nutzer, Pdf Viewer Plus ist nun auch in F-Droid verfügbar!</string>
     <string name="appChangelog">Änderungshistorie</string>
     <string name="ok">Ok</string>
     <string name="title_permission">Speicherberechtigungen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -47,7 +47,5 @@
     <string name="fling">Seitenumbruch</string>
     <string name="qualitysettings">Qualität</string>
     <string name="scrollsettings">Scrollen</string>
-    <string name="reload">PDF-Datei neu laden</string>
-    <string name="reload_sum">Um die Änderungen anzuwenden, muss die PDF-Datei neu geladen werden.</string>
     <string name="buttonLog">Weiter</string>
 </resources>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -59,10 +59,6 @@
         SOFTWARE.
     </string>
 
-    <string name="notice">
-        ¡Pdf Viewer Plus ahora también está en F-Droid!
-    </string>
-
     <string name="appChangelog">Registro de cambios</string>
     <string name="ok">Ok</string>
     <string name="title_permission">Permisos de almacenamiento</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -109,8 +109,6 @@
     <string name="qualitysettings">Calidad</string>
     <string name="scrollsettings">Deslizamiento</string>
     <string name="title_activity_settings">Configuración</string>
-    <string name="reload">Recargar el visor PDF</string>
-    <string name="reload_sum">Para aplicar los cambios, el visor PDF debe ser recargado.</string>
     <string name="buttonLog">Continuar</string>
     <string name="show_in_launcher">Mostrar aplicación en su lanzador de aplicaciones</string>
     <string name="show_in_launcher_summary">Puede que necesite reiniciar su lanzador para que esta opción se aplique</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -54,8 +54,6 @@
     <string name="qualitysettings">Qualité</string>
     <string name="scrollsettings">Défilement</string>
     <string name="title_activity_settings">Préférences</string>
-    <string name="reload">Recharger le PDF</string>
-    <string name="reload_sum">Pour que les changements soient appliqués, le PDF doit être rechargé.</string>
     <string name="buttonLog">Continuer</string>
     <string name="show_in_launcher">Afficher l\'application dans le lanceur</string>
     <string name="show_in_launcher_summary">Vous devrez peut-être redémarrer votre lanceur pour que cette option prenne effet</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -16,7 +16,6 @@
     <string name="description__intro">Un lecteur PDF simple.</string>
     <string name="myLicense">Licence</string>
     <string name="privacy">Politique de confidentialité</string>
-    <string name="notice">Chers utilisateurs,\n\nPdf Viewer Plus est désormais disponible sur F-Droid !</string>
     <string name="appChangelog">Journal des modifications</string>
     <string name="ok">Ok</string>
     <string name="title_permission">Autorisation de stockage</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -65,8 +65,6 @@
     <string name="qualitysettings">Qualità</string>
     <string name="scrollsettings">Scorrimento</string>
     <string name="title_activity_settings">Impostazioni</string>
-    <string name="reload">Ricarica PDF</string>
-    <string name="reload_sum">Per applicare le modifiche, il PDF deve essere ricaricato.</string>
     <string name="buttonLog">Continua</string>
     <string name="show_in_launcher">Mostra l\'applicazione nel launcher</string>
     <string name="show_in_launcher_summary">Potrebbe essere necessario riavviare il launcher affinché la modifica abbia effetto</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -10,7 +10,7 @@
     <string name="version">Versione</string>
     <string name="intro">Ripeti l\'introduzione</string>
     <string name="email">Email</string>
-    <string name="description_open">Ovviamente quest\'app è open source. Puoi dare il tuo contributo quando vuoi. Il link al codice sorgente è nella sezione informazioni.</string>
+    <string name="description_open">Ovviamente quest\'app è open source. Puoi dare il tuo contributo quando vuoi. Il link al codice sorgente è nella sezione Informazioni.</string>
     <string name="title_open">Libertà</string>
     <string name="description__intro">Un semplice visualizzatore di documenti PDF.</string>
     <string name="myLicense">Licenza</string>
@@ -62,7 +62,7 @@
     <string name="snap_summary">Centra la visuale sulla pagina corrente dopo ogni scorrimento</string>
     <string name="fling">Scorrimento rapido</string>
     <string name="fling_summary">Passa direttamente alla pagina successiva con uno scorrimento rapido</string>
-    <string name="qualitysettings">Qualità</string>
+    <string name="qualitysettings">Visualizzazione</string>
     <string name="scrollsettings">Scorrimento</string>
     <string name="title_activity_settings">Impostazioni</string>
     <string name="buttonLog">Continua</string>
@@ -75,4 +75,5 @@
     <string name="protected_pdf">PDF protetto</string>
     <string name="enter_password">Inserisci la password corretta per aprire il documento:</string>
     <string name="wrong_password">Password errata.</string>
+    <string name="dark_pdf">Modalità scura per il PDF</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -16,10 +16,6 @@
     <string name="myLicense">Licenza</string>
     <string name="privacy">Informativa sulla privacy</string>
 
-    <string name="notice">
-        Cari utenti,\n\nPdf Viewer Plus adesso è anche su F-Droid!
-    </string>
-
     <string name="appChangelog">Novità</string>
     <string name="ok">Ok</string>
     <string name="title_permission">Permessi di archiviazione</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -103,8 +103,6 @@
     <string name="qualitysettings">Qualidade</string>
     <string name="scrollsettings">Rolagem</string>
     <string name="title_activity_settings">Configurações</string>
-    <string name="reload">Recarregar PDF</string>
-    <string name="reload_sum">Para aplicar as mudanças, o PDF deve ser recarregado.</string>
     <string name="buttonLog">Continuar</string>
 
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -55,10 +55,6 @@
         SOFTWARE.
     </string>
 
-    <string name="notice">
-        Olá usuários,\n\nO Pdf Viewer Plus agora também está no F-Droid!
-    </string>
-
     <string name="appChangelog">Registro de mudanças</string>
     <string name="ok">Ok</string>
     <string name="title_permission">Permissão de armazenamento</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -56,7 +56,6 @@
     <string name="contribution">Авторы</string>
 
     <string name="ok">ОК</string>
-    <string name="notice">Уважаемые пользователи, Pdf Viewer Plus теперь также доступен в F-Droid!</string>
     <string name="version">Версия</string>
     <string name="devnotice">Уведомление разработчика</string>
 

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -40,8 +40,6 @@
     <string name="scrollsettings">Прокрутка</string>
     <string name="scroll">Горизонтальная прокрутка</string>
     <string name="fling">Перелистывание страниц</string>
-    <string name="reload">Перезагрузить PDF файл</string>
-    <string name="reload_sum">Чтобы внести изменения, необходимо перезагрузить PDF файл.</string>
 
     <!-- About -->
     <string name="action_about">О приложении</string>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -29,8 +29,6 @@
     <color name="colorAccent">#00cc99</color>
     <color name="colorWhite">#ffffff</color>
 
-    <color name="colorViewerDarkBG">#292929</color>
-
     <!-- Used for designer preview -->
     <color name="cyanea_primary_reference">#2481a1</color>
     <color name="cyanea_accent_reference">#00cc99</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -109,8 +109,6 @@
     <string name="qualitysettings">Visual</string>
     <string name="scrollsettings">Scrolling</string>
     <string name="title_activity_settings">Settings</string>
-    <string name="reload">Reload PDF</string>
-    <string name="reload_sum">In order to make changes, the PDF must be reloaded.</string>
     <string name="buttonLog">Continue</string>
     <string name="show_in_launcher">Show app in launcher</string>
     <string name="show_in_launcher_summary">You may need to restart your launcher for this option to take effect</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,10 +59,6 @@
         SOFTWARE.
     </string>
 
-    <string name="notice">
-        Hello Users,\n\nPdf Viewer Plus is now also on F-Droid!
-    </string>
-
     <string name="appChangelog">Change Log</string>
     <string name="ok">Ok</string>
     <string name="title_permission">Storage Permissions</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -43,8 +43,4 @@
 
     </PreferenceCategory>
 
-    <Preference android:title="@string/reload"
-        android:key="reload_pref"
-        android:summary="@string/reload_sum"/>
-
 </PreferenceScreen>


### PR DESCRIPTION
This PR removes the need for the "Reload document" button by automatically reloading the currently opened document when the user exits from the settings activity.
This automatic reload is better than the manual one for a couple of reasons:
- no extra activities are being opened (which would have been kept in Recents screen since multi-document implementation)
- the current position in the document (page number) doesn't get lost since the document is reloaded in the same activity