### PR TITLE
Fix bottom bar colors and ripple (this time for real)

### DIFF
--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -63,6 +63,7 @@ import com.github.barteksc.pdfviewer.util.Constants;
 import com.github.barteksc.pdfviewer.util.FitPolicy;
 import com.gsnathan.pdfviewer.databinding.ActivityMainBinding;
 import com.gsnathan.pdfviewer.databinding.PasswordDialogBinding;
+import com.jaredrummler.cyanea.Cyanea;
 import com.jaredrummler.cyanea.app.CyaneaAppCompatActivity;
 import com.jaredrummler.cyanea.prefs.CyaneaSettingsActivity;
 import com.shockwave.pdfium.PdfDocument;
@@ -125,6 +126,13 @@ public class MainActivity extends CyaneaAppCompatActivity {
         } else {
             displayFromUri(uri);
         }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        // Workaround for android:background XML attribute not being applied on all devices
+        viewBinding.bottomNavigation.setBackgroundColor(Cyanea.getInstance().getPrimary());
     }
 
     private void onFirstInstall() {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -51,7 +51,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"
-        app:itemBackground="@color/cyanea_primary_reference"
         android:minHeight="?android:attr/actionBarSize"
         app:itemIconTint="?menuIconColor"
         app:itemTextColor="?menuIconColor"


### PR DESCRIPTION
I've finally found a way to get the background color of the bottom bar working without breaking ripple.
It simply consists in setting the background color of the BottomNavigationView programmatically in onResume (so that it gets correctly updated when the user changes the theme).

Closes #101 