### PR TITLE
Save activity state the Android way (and ditch AndroidAnnotations)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,15 +40,6 @@ android {
         versionCode 27
         versionName "3.6"
         vectorDrawables.useSupportLibrary = true
-
-        javaCompileOptions {
-            annotationProcessorOptions {
-                includeCompileClasspath = true
-                arguments = [
-                        "androidManifestFile": "$projectDir/src/main/AndroidManifest.xml".toString()
-                ]
-            }
-        }
     }
 
     buildFeatures {
@@ -86,11 +77,6 @@ dependencies {
 
     //Pdf Viewer Library (Proguard config done)
     implementation 'com.github.barteksc:android-pdf-viewer:3.2.0-beta.1'
-
-    //Android Annotations Library (Proguard config not needed)
-    //compileOnly
-    annotationProcessor 'org.androidannotations:androidannotations:4.6.0'
-    implementation 'org.androidannotations:androidannotations-api:4.6.0'
 
     //License Presenter Library (Proguard config not needed)
     implementation 'com.github.franmontiel:AttributionPresenter:1.0.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
         android:theme="@style/Theme.Cyanea.Light.DarkActionBar">
 
         <activity
-            android:name=".MainActivity_"
+            android:name=".MainActivity"
             android:documentLaunchMode="intoExisting">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -74,7 +74,7 @@
         <activity-alias
             android:name=".LauncherAlias"
             android:enabled="true"
-            android:targetActivity=".MainActivity_">
+            android:targetActivity=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -85,7 +85,7 @@
         <activity
             android:name=".AboutActivity"
             android:label="@string/action_about"
-            android:parentActivityName=".MainActivity_" />
+            android:parentActivityName=".MainActivity" />
 
         <activity
             android:name=".MainIntroActivity"
@@ -95,7 +95,7 @@
         <activity
             android:name=".SettingsActivity"
             android:label="@string/settings"
-            android:parentActivityName=".MainActivity_" />
+            android:parentActivityName=".MainActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -69,7 +69,6 @@ import com.shockwave.pdfium.PdfDocument;
 import com.shockwave.pdfium.PdfPasswordException;
 
 import org.androidannotations.annotations.EActivity;
-import org.androidannotations.annotations.NonConfigurationInstance;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -84,6 +83,10 @@ public class MainActivity extends CyaneaAppCompatActivity {
 
     private PrintManager mgr;
     private SharedPreferences prefManager;
+
+    private Uri uri;
+    private int pageNumber = 0;
+    private String pdfPassword;
 
     private boolean isBottomNavigationHidden = false;
 
@@ -118,13 +121,31 @@ public class MainActivity extends CyaneaAppCompatActivity {
         onFirstInstall();
         onFirstUpdate();
 
-        readUriFromIntent(getIntent());
+        if (savedInstanceState != null) {
+            restoreInstanceState(savedInstanceState);
+        } else {
+            readUriFromIntent(getIntent());
+        }
         if (uri == null) {
             pickFile();
             setTitle("");
         } else {
             displayFromUri(uri);
         }
+    }
+
+    @Override
+    protected void onSaveInstanceState(@NonNull Bundle outState) {
+        outState.putParcelable("uri", uri);
+        outState.putInt("pageNumber", pageNumber);
+        outState.putString("pdfPassword", pdfPassword);
+        super.onSaveInstanceState(outState);
+    }
+
+    private void restoreInstanceState(Bundle savedState) {
+        uri = savedState.getParcelable("uri");
+        pageNumber = savedState.getInt("pageNumber");
+        pdfPassword = savedState.getString("pdfPassword");
     }
 
     private void onFirstInstall() {
@@ -163,15 +184,6 @@ public class MainActivity extends CyaneaAppCompatActivity {
 
         uri = intentUri;
     }
-
-    @NonConfigurationInstance
-    Uri uri;
-
-    @NonConfigurationInstance
-    Integer pageNumber = 0;
-
-    @NonConfigurationInstance
-    String pdfPassword;
 
     private String pdfFileName = "";
 

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -329,13 +329,29 @@ public class MainActivity extends CyaneaAppCompatActivity {
 
         String scheme = uri.getScheme();
         if (scheme != null && scheme.contains("http")) {
+            downloadOrShowDownloadedFile(uri);
+        } else {
+            configurePdfViewAndLoad(viewBinding.pdfView.fromUri(uri));
+        }
+    }
+
+    private void downloadOrShowDownloadedFile(Uri uri) {
+        if (downloadedPdfFileContent == null) {
+            downloadedPdfFileContent = (byte[]) getLastCustomNonConfigurationInstance();
+        }
+        if (downloadedPdfFileContent != null) {
+            configurePdfViewAndLoad(viewBinding.pdfView.fromBytes(downloadedPdfFileContent));
+        } else {
             // we will get the pdf asynchronously with the DownloadPDFFile object
             viewBinding.progressBar.setVisibility(View.VISIBLE);
             DownloadPDFFile downloadPDFFile = new DownloadPDFFile(this);
             downloadPDFFile.execute(uri.toString());
-        } else {
-            configurePdfViewAndLoad(viewBinding.pdfView.fromUri(uri));
         }
+    }
+
+    @Override
+    public Object onRetainCustomNonConfigurationInstance() {
+        return downloadedPdfFileContent;
     }
 
     public void hideProgressBar() {

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -85,6 +85,9 @@ public class MainActivity extends CyaneaAppCompatActivity {
     private Uri uri;
     private int pageNumber = 0;
     private String pdfPassword;
+    private String pdfFileName = "";
+
+    private byte[] downloadedPdfFileContent;
 
     private boolean isBottomNavigationHidden = false;
 
@@ -98,6 +101,14 @@ public class MainActivity extends CyaneaAppCompatActivity {
     private final ActivityResultLauncher<String> saveToDownloadPermissionLauncher = registerForActivityResult(
         new RequestPermission(),
         this::saveDownloadedFileAfterPermissionRequest
+    );
+
+    private final ActivityResultLauncher<Intent> settingsLauncher = registerForActivityResult(
+        new StartActivityForResult(),
+        result -> {
+            if (uri != null)
+                displayFromUri(uri);
+        }
     );
 
     @Override
@@ -182,18 +193,6 @@ public class MainActivity extends CyaneaAppCompatActivity {
 
         uri = intentUri;
     }
-
-    private String pdfFileName = "";
-
-    private byte[] downloadedPdfFileContent;
-
-    private final ActivityResultLauncher<Intent> settingsLauncher = registerForActivityResult(
-            new StartActivityForResult(),
-            result -> {
-                if (uri != null)
-                    displayFromUri(uri);
-            }
-    );
 
     void shareFile() {
         startActivity(Utils.emailIntent(pdfFileName, "", getResources().getString(R.string.share), uri));

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -68,7 +68,6 @@ import com.jaredrummler.cyanea.prefs.CyaneaSettingsActivity;
 import com.shockwave.pdfium.PdfDocument;
 import com.shockwave.pdfium.PdfPasswordException;
 
-import org.androidannotations.annotations.EActivity;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -76,7 +75,6 @@ import java.io.IOException;
 
 import static android.content.pm.PackageManager.PERMISSION_DENIED;
 
-@EActivity
 public class MainActivity extends CyaneaAppCompatActivity {
 
     private static final String TAG = MainActivity.class.getSimpleName();
@@ -134,20 +132,6 @@ public class MainActivity extends CyaneaAppCompatActivity {
         }
     }
 
-    @Override
-    protected void onSaveInstanceState(@NonNull Bundle outState) {
-        outState.putParcelable("uri", uri);
-        outState.putInt("pageNumber", pageNumber);
-        outState.putString("pdfPassword", pdfPassword);
-        super.onSaveInstanceState(outState);
-    }
-
-    private void restoreInstanceState(Bundle savedState) {
-        uri = savedState.getParcelable("uri");
-        pageNumber = savedState.getInt("pageNumber");
-        pdfPassword = savedState.getString("pdfPassword");
-    }
-
     private void onFirstInstall() {
         boolean isFirstRun = prefManager.getBoolean("FIRSTINSTALL", true);
         if (isFirstRun) {
@@ -166,6 +150,20 @@ public class MainActivity extends CyaneaAppCompatActivity {
             editor.putBoolean(Utils.getAppVersion(), false);
             editor.apply();
         }
+    }
+
+    @Override
+    protected void onSaveInstanceState(@NonNull Bundle outState) {
+        outState.putParcelable("uri", uri);
+        outState.putInt("pageNumber", pageNumber);
+        outState.putString("pdfPassword", pdfPassword);
+        super.onSaveInstanceState(outState);
+    }
+
+    private void restoreInstanceState(Bundle savedState) {
+        uri = savedState.getParcelable("uri");
+        pageNumber = savedState.getInt("pageNumber");
+        pdfPassword = savedState.getString("pdfPassword");
     }
 
     private void readUriFromIntent(Intent intent) {


### PR DESCRIPTION
This PR reworks the way MainActivity state is preserved to use `onSaveInstanceState` instead of AndroidAnnotations' `NonConfigurationInstance` annotation.
The main advantage of this old-school (but evergreen) method is that activity state is correctly preserved even after the app process gets terminated by the system (for example due to low memory constraints). Instead, `NonConfigurationInstance` uses `Activity.onRetainNonConfigurationInstance` under the hood, which works only with configuration changes.
With this change the app no longer needs to depend on AndroidAnnotations, so I removed the dependency altogether.

I've also used the aforementioned `onRetainNonConfigurationInstance` method to avoid re-downloading the entire PDF on screen rotation (and theme/settings update too) when the app is used open a file via HTTP. It's a deprecated API, I know, but I didn't want to set up a ViewModel just for a single byte array.
 