### PR TITLE
Simplify logic for reading intent URI

### DIFF
--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -74,8 +74,6 @@ import org.jetbrains.annotations.NotNull;
 import java.io.File;
 import java.io.IOException;
 
-import static android.content.pm.PackageManager.PERMISSION_DENIED;
-
 public class MainActivity extends CyaneaAppCompatActivity {
 
     private static final String TAG = MainActivity.class.getSimpleName();
@@ -187,19 +185,9 @@ public class MainActivity extends CyaneaAppCompatActivity {
 
     private void readUriFromIntent(Intent intent) {
         Uri intentUri = intent.getData();
-        if (intentUri == null) {
-            return;
+        if (intentUri != null) {
+            uri = intentUri;
         }
-
-        // Happens when the content provider URI used to open the document expires
-        if ("content".equals(intentUri.getScheme()) &&
-            checkCallingOrSelfUriPermission(intentUri, Intent.FLAG_GRANT_READ_URI_PERMISSION) == PERMISSION_DENIED) {
-            Log.w(TAG, "No read permission for URI " + intentUri);
-            uri = null;
-            return;
-        }
-
-        uri = intentUri;
     }
 
     void shareFile() {

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -104,10 +104,7 @@ public class MainActivity extends CyaneaAppCompatActivity {
 
     private final ActivityResultLauncher<Intent> settingsLauncher = registerForActivityResult(
         new StartActivityForResult(),
-        result -> {
-            if (uri != null)
-                displayFromUri(uri);
-        }
+        result -> displayFromUri(uri)
     );
 
     @Override
@@ -132,14 +129,11 @@ public class MainActivity extends CyaneaAppCompatActivity {
         if (savedInstanceState != null) {
             restoreInstanceState(savedInstanceState);
         } else {
-            readUriFromIntent(getIntent());
+            uri = getIntent().getData();
+            if (uri == null)
+                pickFile();
         }
-        if (uri == null) {
-            pickFile();
-            setTitle("");
-        } else {
-            displayFromUri(uri);
-        }
+        displayFromUri(uri);
     }
 
     @Override
@@ -181,13 +175,6 @@ public class MainActivity extends CyaneaAppCompatActivity {
         uri = savedState.getParcelable("uri");
         pageNumber = savedState.getInt("pageNumber");
         pdfPassword = savedState.getString("pdfPassword");
-    }
-
-    private void readUriFromIntent(Intent intent) {
-        Uri intentUri = intent.getData();
-        if (intentUri != null) {
-            uri = intentUri;
-        }
     }
 
     void shareFile() {
@@ -319,6 +306,11 @@ public class MainActivity extends CyaneaAppCompatActivity {
     }
 
     void displayFromUri(Uri uri) {
+        if (uri == null) {
+            setTitle("");
+            return;
+        }
+
         pdfFileName = getFileName(uri);
         setTitle(pdfFileName);
         setTaskDescription(new ActivityManager.TaskDescription(pdfFileName));

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -400,6 +400,8 @@ public class MainActivity extends CyaneaAppCompatActivity {
                         result = cursor.getString(indexDisplayName);
                     }
                 }
+            } catch (Exception e) {
+                Log.w(TAG, "Couldn't retrieve file name", e);
             }
         }
         if (result == null) {

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -76,7 +76,7 @@ import java.io.IOException;
 
 public class MainActivity extends CyaneaAppCompatActivity {
 
-    private static final String TAG = MainActivity.class.getSimpleName();
+    private static final String TAG = "MainActivity";
 
     private PrintManager mgr;
     private SharedPreferences prefManager;


### PR DESCRIPTION
This PR removes the content URI permission check that I added in 56c7304.
I originally added it to handle a rare crash that happens when the user re-opens the a PDF from Recents after a phone reboot. However, that check proved to be unreliable since it caused false negatives (see #107 and #98). To prevent the crash, we now catch exceptions that occur while retrieving the file name from a content provider.

I've taken this opportunity to simplify the logic for reading the incoming Intent URI and also fixed a small bug which caused the file picker to be re-opened every time the user rotated the screen when no document was opened.

Fixes #107 
Fixes #98