### PR TITLE
Miscellaneous fixes to sharing intents

### DIFF
--- a/app/src/main/java/com/gsnathan/pdfviewer/AboutActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/AboutActivity.java
@@ -95,16 +95,8 @@ public class AboutActivity extends CyaneaAppCompatActivity {
                                 .build()
                 )
                 .addAttributions(
-                        new Attribution.Builder("AndroidAnnotations")
-                                .addCopyrightNotice("Copyright 2012-2016 eBusiness Information\n" +
-                                        "Copyright 2016-2017 the AndroidAnnotations project")
-                                .addLicense(License.APACHE)
-                                .setWebsite("https://github.com/androidannotations/androidannotations")
-                                .build()
-                )
-                .addAttributions(
                         new Attribution.Builder("AppIntro")
-                                .addCopyrightNotice("Copyright 2018 paorotolo")
+                                .addCopyrightNotice("Copyright 2018 Paolo Rotolo")
                                 .addLicense(License.APACHE)
                                 .setWebsite("https://github.com/paolorotolo/AppIntro")
                                 .build()

--- a/app/src/main/java/com/gsnathan/pdfviewer/AboutActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/AboutActivity.java
@@ -24,10 +24,12 @@
 
 package com.gsnathan.pdfviewer;
 
+import android.content.ActivityNotFoundException;
 import android.os.Bundle;
 
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.Toast;
 
 import com.franmontiel.attributionpresenter.AttributionPresenter;
 import com.franmontiel.attributionpresenter.entities.Attribution;
@@ -149,7 +151,12 @@ public class AboutActivity extends CyaneaAppCompatActivity {
     }
 
     public void emailDev(View v) {
-        startActivity(Utils.emailIntent("gokulswamilive@gmail.com", "Pdf Viewer Plus", APP_VERSION_RELEASE));
+        String email = "gokulswamilive@gmail.com";
+        try {
+            startActivity(Utils.emailIntent(email, "Pdf Viewer Plus", APP_VERSION_RELEASE));
+        } catch (ActivityNotFoundException e) {
+            Toast.makeText(this, email, Toast.LENGTH_SHORT).show();
+        }
     }
 
     public void navToGit(View v) {

--- a/app/src/main/java/com/gsnathan/pdfviewer/AboutActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/AboutActivity.java
@@ -149,7 +149,7 @@ public class AboutActivity extends CyaneaAppCompatActivity {
     }
 
     public void emailDev(View v) {
-        startActivity(Utils.emailIntent("gokulswamilive@gmail.com", "Pdf Viewer Plus", APP_VERSION_RELEASE, "Send email..."));
+        startActivity(Utils.emailIntent("gokulswamilive@gmail.com", "Pdf Viewer Plus", APP_VERSION_RELEASE));
     }
 
     public void navToGit(View v) {

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -203,7 +203,13 @@ public class MainActivity extends CyaneaAppCompatActivity {
     }
 
     void shareFile() {
-        startActivity(Utils.fileShareIntent(getResources().getString(R.string.share), pdfFileName, uri));
+        Intent sharingIntent;
+        if (uri.getScheme() != null && uri.getScheme().startsWith("http")) {
+            sharingIntent = Utils.plainTextShareIntent(getString(R.string.share), uri.toString());
+        } else {
+            sharingIntent = Utils.fileShareIntent(getString(R.string.share), pdfFileName, uri);
+        }
+        startActivity(sharingIntent);
     }
 
     private void openSelectedDocument(Uri selectedDocumentUri) {

--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -203,7 +203,7 @@ public class MainActivity extends CyaneaAppCompatActivity {
     }
 
     void shareFile() {
-        startActivity(Utils.emailIntent(pdfFileName, "", getResources().getString(R.string.share), uri));
+        startActivity(Utils.fileShareIntent(getResources().getString(R.string.share), pdfFileName, uri));
     }
 
     private void openSelectedDocument(Uri selectedDocumentUri) {

--- a/app/src/main/java/com/gsnathan/pdfviewer/Utils.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/Utils.java
@@ -71,12 +71,12 @@ public class Utils {
     }
 
     static Intent fileShareIntent(String chooserTitle, String fileName, Uri fileUri) {
-        Intent email = new Intent(Intent.ACTION_SEND);
-        email.setType("application/pdf");
-        email.putExtra(Intent.EXTRA_STREAM, fileUri);
-        email.setClipData(new ClipData(fileName, new String[] { "application/pdf" }, new ClipData.Item(fileUri)));
-        email.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        return Intent.createChooser(email, chooserTitle);
+        Intent intent = new Intent(Intent.ACTION_SEND);
+        intent.setType("application/pdf");
+        intent.putExtra(Intent.EXTRA_STREAM, fileUri);
+        intent.setClipData(new ClipData(fileName, new String[] { "application/pdf" }, new ClipData.Item(fileUri)));
+        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        return Intent.createChooser(intent, chooserTitle);
     }
 
     static Intent linkIntent(String url) {

--- a/app/src/main/java/com/gsnathan/pdfviewer/Utils.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/Utils.java
@@ -71,15 +71,13 @@ public class Utils {
         return Intent.createChooser(email, title);
     }
 
-    static Intent emailIntent(String subject, String text, String title, Uri filePath) {
+    static Intent fileShareIntent(String chooserTitle, String fileName, Uri fileUri) {
         Intent email = new Intent(Intent.ACTION_SEND);
-        email.setType("text/email");
-        email.putExtra(Intent.EXTRA_SUBJECT, subject);
-        email.putExtra(Intent.EXTRA_TEXT, text);
-        email.putExtra(Intent.EXTRA_STREAM, filePath);
-        email.setClipData(new ClipData(subject, new String[] { "application/pdf" }, new ClipData.Item(filePath)));
+        email.setType("application/pdf");
+        email.putExtra(Intent.EXTRA_STREAM, fileUri);
+        email.setClipData(new ClipData(fileName, new String[] { "application/pdf" }, new ClipData.Item(fileUri)));
         email.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        return Intent.createChooser(email, title);
+        return Intent.createChooser(email, chooserTitle);
     }
 
     static Intent linkIntent(String url) {

--- a/app/src/main/java/com/gsnathan/pdfviewer/Utils.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/Utils.java
@@ -24,6 +24,7 @@
 
 package com.gsnathan.pdfviewer;
 
+import android.content.ClipData;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Color;
@@ -76,6 +77,8 @@ public class Utils {
         email.putExtra(Intent.EXTRA_SUBJECT, subject);
         email.putExtra(Intent.EXTRA_TEXT, text);
         email.putExtra(Intent.EXTRA_STREAM, filePath);
+        email.setClipData(new ClipData(subject, new String[] { "application/pdf" }, new ClipData.Item(filePath)));
+        email.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         return Intent.createChooser(email, title);
     }
 

--- a/app/src/main/java/com/gsnathan/pdfviewer/Utils.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/Utils.java
@@ -62,13 +62,12 @@ public class Utils {
         log.show(context.getSupportFragmentManager(), "Log");
     }
 
-    static Intent emailIntent(String emailAddress, String subject, String text, String title) {
-        Intent email = new Intent(Intent.ACTION_SEND);
-        email.setType("text/email");
-        email.putExtra(Intent.EXTRA_EMAIL, new String[]{emailAddress});
+    static Intent emailIntent(String emailAddress, String subject, String text) {
+        Intent email = new Intent(Intent.ACTION_SENDTO);
+        email.setData(Uri.parse("mailto:" + emailAddress));
         email.putExtra(Intent.EXTRA_SUBJECT, subject);
         email.putExtra(Intent.EXTRA_TEXT, text);
-        return Intent.createChooser(email, title);
+        return email;
     }
 
     static Intent fileShareIntent(String chooserTitle, String fileName, Uri fileUri) {

--- a/app/src/main/java/com/gsnathan/pdfviewer/Utils.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/Utils.java
@@ -70,6 +70,13 @@ public class Utils {
         return email;
     }
 
+    static Intent plainTextShareIntent(String chooserTitle, String text) {
+        Intent intent = new Intent(Intent.ACTION_SEND);
+        intent.setType("text/plain");
+        intent.putExtra(Intent.EXTRA_TEXT, text);
+        return Intent.createChooser(intent, chooserTitle);
+    }
+
     static Intent fileShareIntent(String chooserTitle, String fileName, Uri fileUri) {
         Intent intent = new Intent(Intent.ACTION_SEND);
         intent.setType("application/pdf");


### PR DESCRIPTION
This PR makes some changes and fixes to sharing intents:
- fixes MIME type when sharing a PDF (it was incorrectly set to text/email before). One positive effect is that now Bluetooth sharing appears in the possible choices.
- adds ClipData to the sharing intent to fix #106
- works around sharing of downloaded PDFs by sharing only their URL. The proper way to share them (not just the URL) would be to store the file to cache folder and then use a FileProvider, but I hadn't time to implement it.

I've also noticed that the intent used to send an email to the developer was displaying the sharesheet instead of redirecting the user to the email app, so I fixed it.

**Bonus**: I've removed AndroidAnnotations from the list of used libraries. I should have done that in #105.