### PR TITLE
Add an option to keep the screen on while reading

### DIFF
--- a/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/MainActivity.java
@@ -41,6 +41,7 @@ import android.preference.PreferenceManager;
 import android.print.PrintManager;
 import android.provider.OpenableColumns;
 import android.util.Log;
+import android.view.WindowManager;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.MotionEvent;
@@ -139,6 +140,10 @@ public class MainActivity extends CyaneaAppCompatActivity {
     @Override
     public void onResume() {
         super.onResume();
+        getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        if (prefManager.getBoolean("screen_on_pref", false)) {
+            getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        }
         // Workaround for android:background XML attribute not being applied on all devices
         viewBinding.bottomNavigation.setBackgroundColor(Cyanea.getInstance().getPrimary());
     }

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -72,4 +72,5 @@
     <string name="enter_password">Inserisci la password corretta per aprire il documento:</string>
     <string name="wrong_password">Password errata.</string>
     <string name="dark_pdf">Modalità scura per il PDF</string>
+    <string name="keep_screen_on">Mantieni lo schermo acceso</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -119,4 +119,5 @@
 
 
     <string name="dark_pdf">Dark theme for PDF</string>
+    <string name="keep_screen_on">Keep the screen on</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -22,6 +22,10 @@
             android:defaultValue="false"
             android:title="@string/dark_pdf" android:key="pdftheme_pref"/>
 
+        <SwitchPreference
+            android:defaultValue="false"
+            android:title="@string/keep_screen_on" android:key="screen_on_pref"/>
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
I've implemented a small quality-of-life change that I really felt the need for.
When the newly added "Keep the screen on" option is toggled, the screen will be kept on while the app is on screen.

Implementation detail: I set the KEEP_SCREEN_ON flag in `onResume` (instead of `onCreate`) so that the option takes effect as soon as the user exits from Settings, without the need to reopen the app.