### PR TITLE
Remember the pages you were on in a PDF even if the app is closed.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,6 +66,12 @@ android {
 }
 
 dependencies {
+    def room_version = "2.3.0"
+
+    // Room
+    implementation "androidx.room:room-runtime:$room_version"
+    annotationProcessor "androidx.room:room-compiler:$room_version"
+
     implementation 'androidx.appcompat:appcompat:1.3.0-beta01'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 

--- a/app/src/main/java/com/gsnathan/pdfviewer/AppDatabase.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/AppDatabase.java
@@ -1,0 +1,9 @@
+package com.gsnathan.pdfviewer;
+
+import androidx.room.Database;
+import androidx.room.RoomDatabase;
+
+@Database(entities = {SavedLocation.class}, version = 1, exportSchema = false)
+public abstract class AppDatabase extends RoomDatabase {
+    public abstract SavedLocationDao savedLocationDao();
+}

--- a/app/src/main/java/com/gsnathan/pdfviewer/SavedLocation.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/SavedLocation.java
@@ -1,0 +1,23 @@
+package com.gsnathan.pdfviewer;
+
+import androidx.annotation.NonNull;
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.room.PrimaryKey;
+
+import org.jetbrains.annotations.NotNull;
+
+@Entity
+public class SavedLocation {
+    public SavedLocation(@NotNull String location, int pageNumber) {
+        this.location = location;
+        this.pageNumber = pageNumber;
+    }
+
+    @PrimaryKey
+    @NonNull
+    public String location;
+
+    @ColumnInfo(name = "pageNumber")
+    public int pageNumber;
+}

--- a/app/src/main/java/com/gsnathan/pdfviewer/SavedLocationDao.java
+++ b/app/src/main/java/com/gsnathan/pdfviewer/SavedLocationDao.java
@@ -1,0 +1,15 @@
+package com.gsnathan.pdfviewer;
+
+import androidx.room.Dao;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
+import androidx.room.Query;
+
+@Dao
+public interface SavedLocationDao {
+    @Query("SELECT pageNumber FROM SavedLocation WHERE location = :location")
+    Integer findSavedPage(String location);
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    void insert(SavedLocation saveLocations);
+}


### PR DESCRIPTION
This change persists the page in a PDF to a database and then restores it when reopening a PDF. In other words, even if you completely close the app/restart your phone/etc. it will still remember where you were in a PDF. It remembers forever. It would probably take on the order of opening 10,000 distinct PDFs to have the database grow to 1 megabyte.

Some implementation details:

I didn't want to pull in something like RxJava and RxAndroid just for this, so I do the asynchronous handling using `java.util.concurrent` directly as the deprecation message for [`AsyncTask`](https://developer.android.com/reference/android/os/AsyncTask) suggests. It sounds like you are going to rewrite to Kotlin, so then using Kotlin's coroutines would be the recommended pattern.

I didn't do much testing on older versions. I ran it in an emulator using API Level 27 and my phone is API Level 29 or 30. I think [Android Room](https://developer.android.com/training/data-storage/room#java) will work a decent ways back.

Writing the page to the DB every time it changes seems fine, performance-wise, in practice for me.